### PR TITLE
Update readme & url in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Fairing
 
-Easily train and serve ML models on Kubernetes, directly from your python code.  
+Easily train ML models on Kubernetes, directly from your python code.  
 
-This projects uses [Metaparticle](http://metaparticle.io/) behind the scene.
-
-fairing allows you to express how you want your model to be trained and served using native python decorators.  
+Fairing allows you to express how you want your model to be trained using python decorators.  
 
 
 ## Table of Contents

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     name='fairing',
     version='0.0.3',
     author="William Buchwalter",
-    description="Easily train and serve ML models on Kubernetes, directly from your python code.",
+    description="Easily train ML models on Kubernetes, directly from your python code.",
     url="https://github.com/kubeflow/fairing",
     packages=setuptools.find_packages(),
     package_data={},

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     version='0.0.3',
     author="William Buchwalter",
     description="Easily train and serve ML models on Kubernetes, directly from your python code.",
-    url="https://github.com/wbuchwalter/fairing",
+    url="https://github.com/kubeflow/fairing",
     packages=setuptools.find_packages(),
     package_data={},
     include_package_data=False,


### PR DESCRIPTION
* Fixes the url in `setup.py`
* Removes mention of serving from the doc for now. We may want to add that back later when/if we implement a more solid solution but for now it's a bit misleading.

cc @r2d4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/17)
<!-- Reviewable:end -->
