### PR TITLE
Fix licence classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import json
 
 setuptools.setup(
     name='fairing',
-    version='0.0.4.dev16',
+    version='0.0.3',
     author="William Buchwalter",
     description="Easily train ML models on Kubernetes, directly from your python code.",
     url="https://github.com/kubeflow/fairing",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import json
 
 setuptools.setup(
     name='fairing',
-    version='0.0.3',
+    version='0.0.4.dev16',
     author="William Buchwalter",
     description="Easily train ML models on Kubernetes, directly from your python code.",
     url="https://github.com/kubeflow/fairing",
@@ -13,7 +13,7 @@ setuptools.setup(
     zip_safe=False,
     classifiers=(
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache License 2.0",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ),
     install_requires=[


### PR DESCRIPTION
Current licence classifier is invalid and prevents pushing new release (or test release) with error:
 
> HTTPError: 400 Client Error: Invalid value for classifiers. Error: 'License :: OSI Approved :: Apache License 2.0' is not a valid choice for this field for url: https://test.pypi.org/legacy/ 

Based on https://pypi.org/pypi?%3Aaction=list_classifiers, the only valid Apache classifier is:   
`License :: OSI Approved :: Apache Software License`

See https://github.com/pypa/warehouse/issues/2996

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/19)
<!-- Reviewable:end -->
