### PR TITLE
avoid launching both chief and worker pods when running a non distributed job

### DIFF
--- a/fairing/training/kubeflow/decorators.py
+++ b/fairing/training/kubeflow/decorators.py
@@ -25,6 +25,7 @@ class DistributedTraining(Training):
         super(DistributedTraining, self).__init__(namespace)
         self.distribution = {
             'Worker': worker_count,
-            'PS': ps_count
+            'PS': ps_count,
+            'Chief': 1
         }
     

--- a/fairing/training/kubeflow/deployment.py
+++ b/fairing/training/kubeflow/deployment.py
@@ -20,17 +20,18 @@ class KubeflowDeployment(deployment.NativeDeployment):
         worker_replica_spec['template'] = pod_template_spec
 
         ps_replica_spec = {}
-        ps_replica_spec['replicas'] = self.distribution['PS']
+        ps_replica_spec['replicas'] = self.distribution.get('PS', 0)
         ps_replica_spec['template'] = pod_template_spec
 
         chief_replica_spec = {}
-        chief_replica_spec['replicas'] = 1
+        chief_replica_spec['replicas'] = self.distribution.get('Chief', 0)
         chief_replica_spec['template'] = pod_template_spec
 
         spec = {} 
         spec['tfReplicaSpecs'] = {}
-        spec['tfReplicaSpecs']['Chief'] = chief_replica_spec
         spec['tfReplicaSpecs']['Worker'] = worker_replica_spec
+        if chief_replica_spec['replicas'] > 0:
+            spec['tfReplicaSpecs']['Chief'] = chief_replica_spec
         if ps_replica_spec['replicas'] > 0:
             spec['tfReplicaSpecs']['PS'] = ps_replica_spec
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         'notebook==5.6.0',
         'jupyter==1.0.0',
         'numpy==1.15.0',
-        'kubernetes==6.0.0',
+        'kubernetes==8.0.1',
         'future==0.17.1',
         'six==1.11.0',
         'httplib2==0.12.0',


### PR DESCRIPTION
when triggering a non distributed job in kubeflow it will create two pods(1 worker, 1 chief). 
This will fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/50)
<!-- Reviewable:end -->
