### PR TITLE
explicitly set restart_policy to never for job

### DIFF
--- a/fairing/deployers/job/job.py
+++ b/fairing/deployers/job/job.py
@@ -40,6 +40,7 @@ class Job(DeployerInterface):
         self.job_id = str(uuid.uuid1())
         self.labels['fairing-id'] = self.job_id
         pod_template_spec = self.generate_pod_template_spec(pod_spec)
+        pod_template_spec.spec.restart_policy = 'Never'
         self.deployment_spec = self.generate_deployment_spec(pod_template_spec)
         if self.output:
             api = k8s_client.ApiClient()


### PR DESCRIPTION
Job enforces that the pod template spec not have restart_policy set to 'Always' which is the default value. Deployment, however, enforces that restart_policy is not 'Never', so it must be set in the deployer. 

Temporary workaround until we create the entire spec in the deployer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/96)
<!-- Reviewable:end -->
