### PR TITLE
Check additional locations when retrieving project_id and credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 # Command to install dependencies
 install:
     - python setup.py install
+    - pip install --upgrade pytest
 # Command to run tests
 script:
     - pytest

--- a/fairing/cloud/gcp.py
+++ b/fairing/cloud/gcp.py
@@ -1,3 +1,4 @@
+import google.auth
 from google.cloud import storage
 from fairing.constants import constants
 
@@ -22,13 +23,23 @@ class GCSUploader(object):
         return "gs://{}/{}".format(bucket_name, blob_name)
 
 
-def guess_project_name(
-        credentials_file=os.environ.get(constants.GOOGLE_CREDS_ENV)):
-    if credentials_file is None:
-        raise Exception("""No credential file provided.
-        Please set GOOGLE_APPLICATION_CREDENTIALS environment variable to point
-        to a credentials file.""")
-    with open(credentials_file, 'r') as f:
-        data = f.read()
-    parsed_creds_file = json.loads(data)
-    return parsed_creds_file['project_id']
+def guess_project_name(credentials_file=None):
+    # Check credentials file if provided
+    if credentials_file is not None:
+        with open(credentials_file, 'r') as f:
+            data = f.read()
+        parsed_creds_file = json.loads(data)
+        return parsed_creds_file['project_id']
+
+    # Use the google.auth library to retrieve credentials. Checks the following
+    # locations in order:
+    # 1. GOOGLE_APPLICATION_CREDENTIALS environment variable
+    # 2. Google Cloud SDK (gcloud)
+    # 3. App Engine Identity service
+    # 4. Compute Engine Metadata service
+    credentials, project_id = google.auth.default()
+
+    if project_id is None:
+        raise Exception('Could not determine project id.')
+
+    return project_id

--- a/tests/cloud/test_gcp_creds.py
+++ b/tests/cloud/test_gcp_creds.py
@@ -1,0 +1,25 @@
+import pytest
+import json
+from unittest.mock import patch
+
+from fairing.cloud.gcp import guess_project_name
+
+# Test guess_project_name with application default credentials.
+def test_guess_project_name_application_default_file(tmp_path):
+    creds_file = tmp_path / 'credentials'
+    project_id = 'test_project'
+
+    with creds_file.open('w') as f:
+        json.dump({
+            'project_id': project_id
+        }, f)
+
+    assert guess_project_name(str(creds_file)) == project_id
+
+# Test that guess_project_name returns the project returned by
+# google.auth.default when no input file is provided.
+def test_guess_project_name_google_auth(tmp_path):
+    project_id = 'test_project'
+
+    with patch('google.auth.default', return_value=(None, project_id)):
+        assert guess_project_name() == project_id


### PR DESCRIPTION
Currently we are just using a user-provided credentials file or checking the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.

This adds additional checks, e.g. gcloud, allowing authentication with end-user credentials as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/103)
<!-- Reviewable:end -->
