### PR TITLE
[WIP] GCP Serving Deployer

### DIFF
--- a/fairing/deployers/gcp/gcpserving.py
+++ b/fairing/deployers/gcp/gcpserving.py
@@ -5,7 +5,8 @@ from fairing.cloud.gcp import guess_project_name
 from googleapiclient import discovery
 from googleapiclient import errors
 
-class GCPServingJob:
+# TODO: Integrate with DeployerInterface
+class GCPServingDeployer:
     """Handle deploying a trained model to GCP."""
     def __init__(self, project_id=None):
         self._project_id = project_id or guess_project_name()
@@ -58,5 +59,4 @@ class GCPServingJob:
         print('Version created successfully. Access the version at the following URL:')
         print('https://console.cloud.google.com/mlengine/models/{}/versions/{}?project={}'.format(
             model_name, version_name, self._project_id))
-
 

--- a/fairing/deployers/gcp/gcpserving.py
+++ b/fairing/deployers/gcp/gcpserving.py
@@ -1,0 +1,62 @@
+from fairing import utils
+from fairing.deployers.deployer import DeployerInterface
+from fairing.cloud.gcp import guess_project_name
+
+from googleapiclient import discovery
+from googleapiclient import errors
+
+class GCPServingJob:
+    """Handle deploying a trained model to GCP."""
+    def __init__(self, project_id=None):
+        self._project_id = project_id or guess_project_name()
+        self._ml = discovery.build('ml', 'v1')
+
+    def deploy(self, model_dir, model_name, version_name, **deploy_kwargs):
+        """Deploys the model to Cloud ML Engine."""
+        # Check if the model exists
+        try:
+            res = self._ml.projects().models().get(
+                name='projects/{}/models/{}'.format(self._project_id, model_name)
+            ).execute()
+        except errors.HttpError as err:
+            if err.resp['status'] == '404':
+                # Model not found
+                res = None
+            else:
+                # Other error with the command
+                print('Error retrieving the model: {}'.format(err))
+                return
+
+        if res is None:
+            # Create the model
+            try:
+                model_body = {'name': model_name}
+                res = self._ml.projects().models().create(
+                    parent='projects/{}'.format(self._project_id),
+                    body=model_body
+                ).execute()
+            except errors.HttpError as err:
+                print('Error creating the model: {}'.format(err))
+                return
+
+        # Create the version
+        try:
+          version_body = deploy_kwargs
+          version_body['name'] = version_name
+          version_body['deploymentUri'] = model_dir
+          print(version_body)
+
+          res = self._ml.projects().models().versions().create(
+              parent='projects/{}/models/{}'.format(
+                  self._project_id, model_name),
+              body=version_body
+          ).execute()
+        except errors.HttpError as err:
+            print('Error creating the version: {}'.format(err))
+            return
+
+        print('Version created successfully. Access the version at the following URL:')
+        print('https://console.cloud.google.com/mlengine/models/{}/versions/{}?project={}'.format(
+            model_name, version_name, self._project_id))
+
+


### PR DESCRIPTION
Fixes #73 

As container-based deployments are not supported, we are currently integrating with the model / version creation API on ML Engine. As a result, this currently won't fit within the standard Fairing preprocess -> build -> deploy workflow.

Todos for this PR:
* Unit and integration tests
* Add an example using this deployer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/128)
<!-- Reviewable:end -->
