### PR TITLE
 Adding scale tier as a pass through option to GCP deployer

### DIFF
--- a/examples/gcp/hello-world-gpu-pytorch.py
+++ b/examples/gcp/hello-world-gpu-pytorch.py
@@ -1,0 +1,30 @@
+import os
+import fairing
+import time
+import multiprocessing
+
+def train():
+    time.sleep(300)
+    print("Training...")
+    import torch
+    print(torch.cuda.current_device())
+    print(torch.cuda.device(0))
+    print(torch.cuda.device_count())
+    print(torch.cuda.get_device_name(0))
+    time.sleep(1)
+    
+
+if __name__ == '__main__':
+    if os.getenv('FAIRING_RUNTIME', None) is not None:
+        train()
+    else:
+        # Setting up google container repositories (GCR) for storing output containers
+        # You can use any docker container registry istead of GCR
+        GCP_PROJECT = fairing.cloud.gcp.guess_project_name()
+        DOCKER_REGISTRY = 'gcr.io/{}/fairing-job'.format(GCP_PROJECT)
+        file_name = os.path.basename(__file__)
+        print("Executing {} remotely.".format(file_name))
+        fairing.config.set_preprocessor('python', executable=file_name)
+        fairing.config.set_builder('append',base_image='pytorch/pytorch:1.0-cuda10.0-cudnn7-devel', registry=DOCKER_REGISTRY, push=True)
+        fairing.config.set_deployer('gcp', scale_tier='BASIC_GPU')
+        fairing.config.run()

--- a/fairing/deployers/gcp/gcp.py
+++ b/fairing/deployers/gcp/gcp.py
@@ -7,10 +7,19 @@ from googleapiclient import discovery
 from googleapiclient import errors
 
 class GCPJob(DeployerInterface):
-    """Handle submitting training job to GCP."""
-    def __init__(self, project_id=None, region=None):
+    """Handle submitting training job to GCP.
+    Attributes:
+        project_id: Google Cloud project ID to use.
+        region: region in which the job has to be deployed.
+            Ref: https://cloud.google.com/compute/docs/regions-zones/
+        scale_tier: machine type to use for the job. 
+            Ref: https://cloud.google.com/ml-engine/docs/tensorflow/machine-types 
+    """
+
+    def __init__(self, project_id=None, region=None, scale_tier="BASIC"):
         self._project_id = project_id or guess_project_name()
         self._region = region or 'us-central1'
+        self.scale_tier = scale_tier
 
         self._ml = discovery.build('ml', 'v1')
 
@@ -25,7 +34,7 @@ class GCPJob(DeployerInterface):
         request_dict = {
             'jobId': self._job_name,
             'trainingInput': {
-                'scaleTier': 'BASIC',
+                'scaleTier': self.scale_tier,
                 'masterConfig': {
                     'imageUri': image_uri,
                 },


### PR DESCRIPTION
Allows the user to specify machine type and resources like GPU.
Ref: https://cloud.google.com/ml-engine/docs/tensorflow/machine-types

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/130)
<!-- Reviewable:end -->
