### PR TITLE
GCP Serving Deployer

### DIFF
--- a/examples/notebook/deploy-to-gcp.ipynb
+++ b/examples/notebook/deploy-to-gcp.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train Locally and Deploy to GCP\n",
+    "The following notebook trains an XGBoost model locally and deploys the resulting model file to GCP using the ML Engine Online Prediction API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2019 Google Inc. All Rights Reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License.\n",
+    "\n",
+    "# Update the following variables for your project\n",
+    "PROJECT_ID   = '<project-id>'\n",
+    "VERSION_DIR  = 'gs://<bucket-name>/<folder-name>/'\n",
+    "MODEL_NAME   = '<model-name>'\n",
+    "VERSION_NAME = '<version-name>'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define training and evaluation functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import argparse\n",
+    "import pandas as pd\n",
+    "from sklearn.metrics import mean_absolute_error\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import Imputer\n",
+    "from xgboost import XGBRegressor\n",
+    "import urllib.request\n",
+    "\n",
+    "import logging\n",
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "\n",
+    "TRAINING_URL=\"https://raw.githubusercontent.com/kubeflow/examples/master/xgboost_ames_housing/ames_dataset/train.csv\"\n",
+    "TRAINING_FILE=\"train.csv\"\n",
+    "\n",
+    "ESTIMATORS=1000\n",
+    "LEARNING_RATE=0.1\n",
+    "TEST_FRACTION_SIZE=0.25\n",
+    "EARLY_STOPPING_ROUNDS=50\n",
+    "\n",
+    "def run_training_and_eval():\n",
+    "    (train_X, train_y), (test_X, test_y) = read_input()\n",
+    "    model = train_model(train_X,\n",
+    "                        train_y,\n",
+    "                        test_X,\n",
+    "                        test_y,\n",
+    "                        ESTIMATORS,\n",
+    "                        LEARNING_RATE)\n",
+    "\n",
+    "    eval_model(model, test_X, test_y)\n",
+    "\n",
+    "def download(url, file_name):\n",
+    "    with urllib.request.urlopen(url) as response, open(file_name, \"wb\") as file:\n",
+    "        file.write(response.read())\n",
+    "\n",
+    "def read_input(test_size=TEST_FRACTION_SIZE):\n",
+    "    \"\"\"Read input data and split it into train and test.\"\"\"\n",
+    "    download(TRAINING_URL, TRAINING_FILE)\n",
+    "    data = pd.read_csv(TRAINING_FILE)\n",
+    "    data.dropna(axis=0, subset=['SalePrice'], inplace=True)\n",
+    "\n",
+    "    y = data.SalePrice\n",
+    "    X = data.drop(['SalePrice'], axis=1).select_dtypes(exclude=['object'])\n",
+    "\n",
+    "    train_X, test_X, train_y, test_y = train_test_split(X.values,\n",
+    "                                                        y.values,\n",
+    "                                                        test_size=test_size,\n",
+    "                                                        shuffle=False)\n",
+    "\n",
+    "    imputer = Imputer()\n",
+    "    train_X = imputer.fit_transform(train_X)\n",
+    "    test_X = imputer.transform(test_X)\n",
+    "\n",
+    "    return (train_X, train_y), (test_X, test_y)\n",
+    "\n",
+    "def train_model(train_X,\n",
+    "                train_y,\n",
+    "                test_X,\n",
+    "                test_y,\n",
+    "                n_estimators,\n",
+    "                learning_rate):\n",
+    "    \"\"\"Train the model using XGBRegressor.\"\"\"\n",
+    "    model = XGBRegressor(n_estimators=n_estimators,\n",
+    "                      learning_rate=learning_rate)\n",
+    "\n",
+    "    model.fit(train_X,\n",
+    "              train_y,\n",
+    "              early_stopping_rounds=EARLY_STOPPING_ROUNDS,\n",
+    "              eval_set=[(test_X, test_y)])\n",
+    "\n",
+    "    logging.info(\"Best RMSE on eval: %.2f with %d rounds\",\n",
+    "                 model.best_score,\n",
+    "                 model.best_iteration+1)\n",
+    "    return model\n",
+    "\n",
+    "def eval_model(model, test_X, test_y):\n",
+    "    \"\"\"Evaluate the model performance.\"\"\"\n",
+    "    predictions = model.predict(test_X)\n",
+    "    logging.info(\"mean_absolute_error=%.2f\", mean_absolute_error(predictions, test_y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train and evaluate the model locally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(train_X, train_y), (test_X, test_y) = read_input()\n",
+    "model = train_model(train_X,\n",
+    "                        train_y,\n",
+    "                        test_X,\n",
+    "                        test_y,\n",
+    "                        ESTIMATORS,\n",
+    "                        LEARNING_RATE)\n",
+    "\n",
+    "eval_model(model, test_X, test_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export the model using the joblib library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import joblib\n",
+    "joblib.dump(model, 'model.joblib')\n",
+    "!gsutil cp model.joblib {VERSION_DIR}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy the model to GCP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fairing.deployers.gcp.gcpserving import GCPServingDeployer\n",
+    "deployer = GCPServingDeployer()\n",
+    "deployer.deploy(VERSION_DIR, MODEL_NAME, VERSION_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Send a prediction to the deployed model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from googleapiclient import discovery\n",
+    "ml = discovery.build('ml', 'v1')\n",
+    "\n",
+    "resource_name = 'projects/{}/models/{}/versions/{}'.format(PROJECT_ID, MODEL_NAME, VERSION_NAME)\n",
+    "ml.projects().predict(\n",
+    "    name=resource_name,\n",
+    "    body={\n",
+    "        'instances': [\n",
+    "            [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37]\n",
+    "        ]\n",
+    "    }\n",
+    ").execute()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/fairing/deployers/gcp/gcpserving.py
+++ b/fairing/deployers/gcp/gcpserving.py
@@ -12,8 +12,16 @@ class GCPServingDeployer:
         self._project_id = project_id or guess_project_name()
         self._ml = discovery.build('ml', 'v1')
 
+        # Set default deploy kwargs
+        self._deploy_kwargs = {
+            'runtime_version': '1.12',
+            'python_version': '3.5'
+        }
+
     def deploy(self, model_dir, model_name, version_name, **deploy_kwargs):
         """Deploys the model to Cloud ML Engine."""
+        self._deploy_kwargs.update(deploy_kwargs)
+
         # Check if the model exists
         try:
             res = self._ml.projects().models().get(
@@ -42,7 +50,7 @@ class GCPServingDeployer:
 
         # Create the version
         try:
-          version_body = deploy_kwargs
+          version_body = self._deploy_kwargs
           version_body['name'] = version_name
           version_body['deploymentUri'] = model_dir
           print(version_body)
@@ -56,7 +64,7 @@ class GCPServingDeployer:
             print('Error creating the version: {}'.format(err))
             return
 
-        print('Version created successfully. Access the version at the following URL:')
+        print('Version submitted successfully. Access the version at the following URL:')
         print('https://console.cloud.google.com/mlengine/models/{}/versions/{}?project={}'.format(
             model_name, version_name, self._project_id))
 

--- a/fairing/deployers/gcp/gcpserving.py
+++ b/fairing/deployers/gcp/gcpserving.py
@@ -50,16 +50,15 @@ class GCPServingDeployer:
 
         # Create the version
         try:
-          version_body = self._deploy_kwargs
-          version_body['name'] = version_name
-          version_body['deploymentUri'] = model_dir
-          print(version_body)
+            version_body = self._deploy_kwargs
+            version_body['name'] = version_name
+            version_body['deploymentUri'] = model_dir
 
-          res = self._ml.projects().models().versions().create(
-              parent='projects/{}/models/{}'.format(
-                  self._project_id, model_name),
-              body=version_body
-          ).execute()
+            res = self._ml.projects().models().versions().create(
+                parent='projects/{}/models/{}'.format(
+                    self._project_id, model_name),
+                body=version_body
+            ).execute()
         except errors.HttpError as err:
             print('Error creating the version: {}'.format(err))
             return

--- a/fairing/deployers/gcp/gcpserving.py
+++ b/fairing/deployers/gcp/gcpserving.py
@@ -1,0 +1,62 @@
+from fairing import utils
+from fairing.deployers.deployer import DeployerInterface
+from fairing.cloud.gcp import guess_project_name
+
+from googleapiclient import discovery
+from googleapiclient import errors
+
+# TODO: Integrate with DeployerInterface
+class GCPServingDeployer:
+    """Handle deploying a trained model to GCP."""
+    def __init__(self, project_id=None):
+        self._project_id = project_id or guess_project_name()
+        self._ml = discovery.build('ml', 'v1')
+
+    def deploy(self, model_dir, model_name, version_name, **deploy_kwargs):
+        """Deploys the model to Cloud ML Engine."""
+        # Check if the model exists
+        try:
+            res = self._ml.projects().models().get(
+                name='projects/{}/models/{}'.format(self._project_id, model_name)
+            ).execute()
+        except errors.HttpError as err:
+            if err.resp['status'] == '404':
+                # Model not found
+                res = None
+            else:
+                # Other error with the command
+                print('Error retrieving the model: {}'.format(err))
+                return
+
+        if res is None:
+            # Create the model
+            try:
+                model_body = {'name': model_name}
+                res = self._ml.projects().models().create(
+                    parent='projects/{}'.format(self._project_id),
+                    body=model_body
+                ).execute()
+            except errors.HttpError as err:
+                print('Error creating the model: {}'.format(err))
+                return
+
+        # Create the version
+        try:
+          version_body = deploy_kwargs
+          version_body['name'] = version_name
+          version_body['deploymentUri'] = model_dir
+          print(version_body)
+
+          res = self._ml.projects().models().versions().create(
+              parent='projects/{}/models/{}'.format(
+                  self._project_id, model_name),
+              body=version_body
+          ).execute()
+        except errors.HttpError as err:
+            print('Error creating the version: {}'.format(err))
+            return
+
+        print('Version created successfully. Access the version at the following URL:')
+        print('https://console.cloud.google.com/mlengine/models/{}/versions/{}?project={}'.format(
+            model_name, version_name, self._project_id))
+

--- a/tests/unit/deployers/gcp/test_gcpserving.py
+++ b/tests/unit/deployers/gcp/test_gcpserving.py
@@ -1,0 +1,124 @@
+"""Tests for GCPServing Deployer."""
+
+import pytest
+import json
+import httplib2
+from unittest.mock import patch
+
+from fairing.deployers.gcp.gcpserving import GCPServingDeployer
+from googleapiclient.errors import HttpError
+
+
+def create_http_error(error_code, message):
+    error_content = json.dumps({
+        'error': {
+            'code': error_code,
+            'message': message,
+            'details': message
+        }
+    }).encode()
+    headers = {'status': str(error_code), 'content-type': 'application/json'}
+    response = httplib2.Response(headers)
+    response.reason = message
+    return HttpError(response, error_content)
+
+
+# Test that deployment fails if an invalid model request is provided.
+def test_invalid_model_request(capsys):
+    with patch('fairing.deployers.gcp.gcpserving.discovery.build') as mock_ml:
+        deployer = GCPServingDeployer(project_id='test_project')
+
+    (mock_ml.return_value.projects.return_value.models.return_value
+     .get.side_effect) = create_http_error(
+        error_code=400, message='invalid request')
+
+    deployer.deploy(
+        model_dir='test_model_dir',
+        model_name='test_model',
+        version_name='test_version')
+
+    captured = capsys.readouterr()
+    assert 'Error retrieving the model' in captured.out
+
+
+# Test that deployment fails if an invalid model creation request is provided.
+def test_invalid_model_creation(capsys):
+    with patch('fairing.deployers.gcp.gcpserving.discovery.build') as mock_ml:
+        deployer = GCPServingDeployer(project_id='test_project')
+
+    (mock_ml.return_value.projects.return_value.models.return_value
+     .get.return_value.execute.return_value) = None
+    (mock_ml.return_value.projects.return_value.models.return_value
+     .create.side_effect) = create_http_error(
+        error_code=400, message='invalid request')
+
+    deployer.deploy(
+        model_dir='test_model_dir',
+        model_name='test_model',
+        version_name='test_version')
+
+    captured = capsys.readouterr()
+    assert 'Error creating the model' in captured.out
+
+
+# Test that a new model is created if not found.
+def test_model_creation_with_404():
+    with patch('fairing.deployers.gcp.gcpserving.discovery.build') as mock_ml:
+        deployer = GCPServingDeployer(project_id='test_project')
+
+    (mock_ml.return_value.projects.return_value.models.return_value
+     .get.side_effect) = create_http_error(
+         error_code=404, message='model not found')
+
+    deployer.deploy(
+        model_dir='test_model_dir',
+        model_name='test_model',
+        version_name='test_version')
+    args, kwargs = (mock_ml.return_value.projects.return_value
+                    .models.return_value.create.call_args)
+
+    assert kwargs['parent'] == 'projects/test_project'
+    assert kwargs['body'] == {'name': 'test_model'}
+
+
+# Test that deployment fails if an invalid version creation request is provided.
+def test_invalid_version_creation(capsys):
+    with patch('fairing.deployers.gcp.gcpserving.discovery.build') as mock_ml:
+        deployer = GCPServingDeployer(project_id='test_project')
+
+    (mock_ml.return_value.projects.return_value.models.return_value
+     .versions.return_value.create.return_value
+     .execute.side_effect) = create_http_error(
+        error_code=400, message='invalid request')
+
+    deployer.deploy(
+        model_dir='test_model_dir',
+        model_name='test_model',
+        version_name='test_version')
+
+    captured = capsys.readouterr()
+    assert 'Error creating the version' in captured.out
+
+
+# Test that a new version is created with the correct arguments.
+def test_valid_creation(capsys):
+    with patch('fairing.deployers.gcp.gcpserving.discovery.build') as mock_ml:
+        deployer = GCPServingDeployer(project_id='test_project')
+
+    deployer.deploy(
+        model_dir='test_model_dir',
+        model_name='test_model',
+        version_name='test_version')
+    args, kwargs = (mock_ml.return_value.projects.return_value.models
+                    .return_value.versions.return_value.create.call_args)
+
+    assert kwargs['parent'] == 'projects/test_project/models/test_model'
+    assert kwargs['body'] == {
+        'name': 'test_version',
+        'deploymentUri': 'test_model_dir',
+        'python_version': '3.5',
+        'runtime_version': '1.12'
+    }
+
+    captured = capsys.readouterr()
+    assert 'Version submitted successfully' in captured.out


### PR DESCRIPTION
Fixes #73 

New version of #128, after updating the branch to be in sync with current master. 

Original description: As container-based deployments are not supported, we are currently integrating with the model / version creation API on ML Engine. As a result, this currently won't fit within the standard Fairing preprocess -> build -> deploy workflow.

Also added unit tests and an example notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/134)
<!-- Reviewable:end -->
