### PR TITLE
Update full_notebook preprocessor to use Papermill

### DIFF
--- a/fairing/preprocessors/base.py
+++ b/fairing/preprocessors/base.py
@@ -42,6 +42,8 @@ class BasePreProcessor(object):
 
         self.set_default_executable()
 
+    # TODO: Add workaround for users who do not want to set an executable for
+    # their command.
     def set_default_executable(self):
         if self.executable is not None:
             return self.executable
@@ -90,10 +92,11 @@ class BasePreProcessor(object):
         return output_file, utils.crc(self._context_tar_path)
 
     def get_command(self):
-        if self.command is None or self.executable is None:
+        if self.command is None:
             return []
         cmd = self.command.copy()
-        cmd.append(os.path.join(self.path_prefix, self.executable))
+        if self.executable is not None:
+            cmd.append(os.path.join(self.path_prefix, self.executable))
         return cmd
 
     def fairing_runtime_files(self):

--- a/fairing/preprocessors/full_notebook.py
+++ b/fairing/preprocessors/full_notebook.py
@@ -8,21 +8,27 @@ class FullNotebookPreProcessor(BasePreProcessor):
     # TODO: Allow configuration of errors / timeout options
     def __init__(self,
                  notebook_file=None,
+                 output_file="fairing_output_notebook.ipynb",
                  input_files=None,
-                 command=["jupyter", "nbconvert", "--stdout", "--to", "notebook", "--execute", "--allow-errors",
-                          "--ExecutePreprocessor.timeout=-1"],
+                 command=None,
                  path_prefix=constants.DEFAULT_DEST_PREFIX,
                  output_map=None):
 
         if notebook_file is None and notebook_util.is_in_notebook():
             notebook_file = notebook_util.get_notebook_name()
 
+        if command is None:
+            command = ["papermill", notebook_file, output_file, "--log-output"]
+            executable = None
+        else:
+            executable = notebook_file
+
         input_files = input_files or []
         if notebook_file not in input_files:
             input_files.append(notebook_file)
 
         super().__init__(
-            executable=notebook_file,
+            executable=executable,
             input_files=input_files,
             command=command,
             output_map=output_map,

--- a/fairing/preprocessors/full_notebook.py
+++ b/fairing/preprocessors/full_notebook.py
@@ -17,20 +17,25 @@ class FullNotebookPreProcessor(BasePreProcessor):
         if notebook_file is None and notebook_util.is_in_notebook():
             notebook_file = notebook_util.get_notebook_name()
 
+        if notebook_file is None:
+            raise ValueError('A notebook_file must be provided.')
+
         if command is None:
             command = ["papermill", notebook_file, output_file, "--log-output"]
-            executable = None
-        else:
-            executable = notebook_file
 
         input_files = input_files or []
         if notebook_file not in input_files:
             input_files.append(notebook_file)
 
         super().__init__(
-            executable=executable,
+            executable=None,
             input_files=input_files,
             command=command,
             output_map=output_map,
             path_prefix=path_prefix)
+
+
+    # We don't want to set a default executable for the full_notebook preprocessor.
+    def set_default_executable(self):
+        pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ oauth2client>=4.0.0
 tornado>=5.1.1,<6.0.0
 google-api-python-client>=1.7.8
 cloudpickle>=0.8
+papermill>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ oauth2client>=4.0.0
 tornado>=5.1.1,<6.0.0
 google-api-python-client>=1.7.8
 cloudpickle>=0.8
-papermill>=0.19.0

--- a/tests/integration/common/test_full_notebook.py
+++ b/tests/integration/common/test_full_notebook.py
@@ -1,0 +1,25 @@
+import pytest
+import fairing
+import os
+
+GCS_PROJECT_ID = fairing.cloud.gcp.guess_project_name()
+DOCKER_REGISTRY = 'gcr.io/{}'.format(GCS_PROJECT_ID)
+NOTEBOOK_PATH = os.path.join(os.path.dirname(__file__), 'test_notebook.ipynb')
+
+def run_full_notebook_submission(capsys, notebook_file, expected_result, deployer='job', builder='append'):
+    base_image = 'gcr.io/{}/fairing-test:latest'.format(GCS_PROJECT_ID)
+    fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY)
+    fairing.config.set_deployer(deployer, namespace='default')
+    fairing.config.set_preprocessor('full_notebook', notebook_file=notebook_file)
+
+    fairing.config.run()
+    captured = capsys.readouterr()
+    assert expected_result in captured.out
+
+def test_full_notebook_job(capsys):
+    run_full_notebook_submission(capsys, NOTEBOOK_PATH, 'Hello World',
+        deployer='job')
+
+def test_full_notebook_tfjob(capsys):
+    run_full_notebook_submission(capsys, NOTEBOOK_PATH, 'Hello World',
+        deployer='tfjob')

--- a/tests/integration/common/test_notebook.ipynb
+++ b/tests/integration/common/test_notebook.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Hello World')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/unit/preprocessors/test_full_notebook_preprocessor.py
+++ b/tests/unit/preprocessors/test_full_notebook_preprocessor.py
@@ -1,0 +1,25 @@
+import pytest
+import tarfile
+import os
+
+from fairing.preprocessors.full_notebook import FullNotebookPreProcessor
+
+NOTEBOOK_PATH = os.path.join(os.path.dirname(__file__), 'test_notebook.ipynb')
+
+def test_preprocess():
+    preprocessor = FullNotebookPreProcessor(notebook_file=NOTEBOOK_PATH)
+    files = preprocessor.preprocess()
+    assert NOTEBOOK_PATH in files
+
+def test_get_command():
+    preprocessor = FullNotebookPreProcessor(notebook_file=NOTEBOOK_PATH)
+    command = preprocessor.get_command()
+    expected_command = 'papermill {} fairing_output_notebook.ipynb --log-output'.format(NOTEBOOK_PATH)
+    assert command == expected_command.split()
+
+def test_context_tar_gz():
+    preprocessor = FullNotebookPreProcessor(notebook_file=NOTEBOOK_PATH)
+    context_file, _ = preprocessor.context_tar_gz()
+    tar = tarfile.open(context_file)
+    tar_notebook = tar.extractfile(tar.getmember(NOTEBOOK_PATH[1:]))
+    assert 'Hello World' in tar_notebook.read().decode()

--- a/tests/unit/preprocessors/test_notebook.ipynb
+++ b/tests/unit/preprocessors/test_notebook.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Hello World')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Fixes #33 

Updates the base preprocessor to not require an executable. This is required because the papermill command format is `papermill <input_notebook> <output_notebook>`, and until now the executable has been appended to the end of the command.

Added the `output_file` argument to full_notebook preprocessor, which specifies the output location of the notebook that has been executed. 

Added papermill to the requirements file. Papermill supports copying the output notebook to a hosted storage service, but this would require appending one of the following suffixes to the requirements: [s3], [gcs], [azure], or [all]. This implementation currently assumes that the user has installed the correct version in their container, but we can also update the requirements file if desired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/162)
<!-- Reviewable:end -->
