### PR TITLE
[WIP] Add job_config to GCP deployer

### DIFF
--- a/fairing/deployers/gcp/gcp.py
+++ b/fairing/deployers/gcp/gcp.py
@@ -14,6 +14,10 @@ class GCPJob(DeployerInterface):
             Ref: https://cloud.google.com/compute/docs/regions-zones/
         scale_tier: machine type to use for the job.
             Ref: https://cloud.google.com/ml-engine/docs/tensorflow/machine-types
+        job_config: Custom job configuration options. If an option is specified
+            in the job_config and as a top-level parameter, the parameter overrides
+            the value in the job_config.
+            Ref: https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs
     """
 
     def __init__(self, project_id=None, region=None, scale_tier=None, job_config=None):
@@ -49,7 +53,8 @@ class GCPJob(DeployerInterface):
             request_dict['trainingInput']['region'] = self._region
 
         try:
-            print(request_dict)
+            print('Creating training job with the following options: {}'.format(
+                str(request_dict)))
             response = self._ml.projects().jobs().create(
                 parent='projects/{}'.format(self._project_id),
                 body=request_dict

--- a/fairing/preprocessors/base.py
+++ b/fairing/preprocessors/base.py
@@ -42,6 +42,8 @@ class BasePreProcessor(object):
 
         self.set_default_executable()
 
+    # TODO: Add workaround for users who do not want to set an executable for
+    # their command.
     def set_default_executable(self):
         if self.executable is not None:
             return self.executable
@@ -90,10 +92,11 @@ class BasePreProcessor(object):
         return output_file, utils.crc(self._context_tar_path)
 
     def get_command(self):
-        if self.command is None or self.executable is None:
+        if self.command is None:
             return []
         cmd = self.command.copy()
-        cmd.append(os.path.join(self.path_prefix, self.executable))
+        if self.executable is not None:
+            cmd.append(os.path.join(self.path_prefix, self.executable))
         return cmd
 
     def fairing_runtime_files(self):

--- a/fairing/preprocessors/full_notebook.py
+++ b/fairing/preprocessors/full_notebook.py
@@ -8,21 +8,27 @@ class FullNotebookPreProcessor(BasePreProcessor):
     # TODO: Allow configuration of errors / timeout options
     def __init__(self,
                  notebook_file=None,
+                 output_file="fairing_output_notebook.ipynb",
                  input_files=None,
-                 command=["jupyter", "nbconvert", "--stdout", "--to", "notebook", "--execute", "--allow-errors",
-                          "--ExecutePreprocessor.timeout=-1"],
+                 command=None,
                  path_prefix=constants.DEFAULT_DEST_PREFIX,
                  output_map=None):
 
         if notebook_file is None and notebook_util.is_in_notebook():
             notebook_file = notebook_util.get_notebook_name()
 
+        if command is None:
+            command = ["papermill", notebook_file, output_file, "--log-output"]
+            executable = None
+        else:
+            executable = notebook_file
+
         input_files = input_files or []
         if notebook_file not in input_files:
             input_files.append(notebook_file)
 
         super().__init__(
-            executable=notebook_file,
+            executable=executable,
             input_files=input_files,
             command=command,
             output_map=output_map,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ oauth2client>=4.0.0
 tornado>=5.1.1,<6.0.0
 google-api-python-client>=1.7.8
 cloudpickle>=0.8
+papermill>=0.19.0


### PR DESCRIPTION
Fixes #161 

Add an option for a user-specified request dictionary with configuration options, when submitting jobs using the GCP deployer. This allows users to provide arbitrary job configurations, in addition to those that are exposed as top-level arguments.

Merge strategy: top-level arguments will override corresponding values set in the request dictionary.

Currently waiting on #162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/163)
<!-- Reviewable:end -->
