### PR TITLE
Update full notebook tests and convert absolute to relative paths

### DIFF
--- a/fairing/preprocessors/full_notebook.py
+++ b/fairing/preprocessors/full_notebook.py
@@ -23,7 +23,7 @@ class FullNotebookPreProcessor(BasePreProcessor):
 
         relative_notebook_file = notebook_file
         # Convert absolute notebook path to relative path
-        if notebook_file[0] == '/':
+        if os.path.isabs(notebook_file[0]):
             relative_notebook_file = os.path.relpath(notebook_file)
 
         if command is None:

--- a/fairing/preprocessors/full_notebook.py
+++ b/fairing/preprocessors/full_notebook.py
@@ -1,3 +1,4 @@
+import os
 from fairing.constants import constants
 
 from .base import BasePreProcessor
@@ -20,12 +21,17 @@ class FullNotebookPreProcessor(BasePreProcessor):
         if notebook_file is None:
             raise ValueError('A notebook_file must be provided.')
 
+        relative_notebook_file = notebook_file
+        # Convert absolute notebook path to relative path
+        if notebook_file[0] == '/':
+            relative_notebook_file = os.path.relpath(notebook_file)
+
         if command is None:
-            command = ["papermill", notebook_file, output_file, "--log-output"]
+            command = ["papermill", relative_notebook_file, output_file, "--log-output"]
 
         input_files = input_files or []
-        if notebook_file not in input_files:
-            input_files.append(notebook_file)
+        if relative_notebook_file not in input_files:
+            input_files.append(relative_notebook_file)
 
         super().__init__(
             executable=None,

--- a/tests/integration/common/requirements.txt
+++ b/tests/integration/common/requirements.txt
@@ -1,0 +1,2 @@
+papermill>=0.19.0
+notebook>=5.6.0

--- a/tests/integration/common/test_full_notebook.py
+++ b/tests/integration/common/test_full_notebook.py
@@ -1,16 +1,22 @@
 import pytest
 import fairing
 import os
+import sys
 
 GCS_PROJECT_ID = fairing.cloud.gcp.guess_project_name()
 DOCKER_REGISTRY = 'gcr.io/{}'.format(GCS_PROJECT_ID)
 NOTEBOOK_PATH = os.path.join(os.path.dirname(__file__), 'test_notebook.ipynb')
 
-def run_full_notebook_submission(capsys, notebook_file, expected_result, deployer='job', builder='append'):
-    base_image = 'gcr.io/{}/fairing-test:latest'.format(GCS_PROJECT_ID)
+def run_full_notebook_submission(capsys, notebook_file, expected_result, deployer='job', builder='docker'):
+    py_version = ".".join([str(x) for x in sys.version_info[0:3]])
+    base_image = 'python:{}'.format(py_version)
     fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY)
     fairing.config.set_deployer(deployer, namespace='default')
-    fairing.config.set_preprocessor('full_notebook', notebook_file=notebook_file)
+
+    requirements_file = os.path.relpath(
+        os.path.join(os.path.dirname(__file__), 'requirements.txt'))
+    fairing.config.set_preprocessor('full_notebook', notebook_file=notebook_file,
+                                    output_map={requirements_file: '/app/requirements.txt'})
 
     fairing.config.run()
     captured = capsys.readouterr()

--- a/tests/unit/preprocessors/test_full_notebook_preprocessor.py
+++ b/tests/unit/preprocessors/test_full_notebook_preprocessor.py
@@ -2,9 +2,12 @@ import pytest
 import tarfile
 import os
 
+import fairing
 from fairing.preprocessors.full_notebook import FullNotebookPreProcessor
+from fairing.constants.constants import DEFAULT_DEST_PREFIX
 
-NOTEBOOK_PATH = os.path.join(os.path.dirname(__file__), 'test_notebook.ipynb')
+NOTEBOOK_PATH = os.path.relpath(
+    os.path.join(os.path.dirname(__file__), 'test_notebook.ipynb'))
 
 def test_preprocess():
     preprocessor = FullNotebookPreProcessor(notebook_file=NOTEBOOK_PATH)
@@ -21,5 +24,7 @@ def test_context_tar_gz():
     preprocessor = FullNotebookPreProcessor(notebook_file=NOTEBOOK_PATH)
     context_file, _ = preprocessor.context_tar_gz()
     tar = tarfile.open(context_file)
-    tar_notebook = tar.extractfile(tar.getmember(NOTEBOOK_PATH[1:]))
+
+    notebook_context_path = os.path.join('app/', NOTEBOOK_PATH)
+    tar_notebook = tar.extractfile(tar.getmember(notebook_context_path))
     assert 'Hello World' in tar_notebook.read().decode()


### PR DESCRIPTION
Fix test failures by updating tests to use Python base image, install Papermill and notebook as explicit dependencies.

Also fixed an issue where absolute notebook paths weren't getting copied to the container by converting to relative paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/171)
<!-- Reviewable:end -->
