### PR TITLE
Add job config to GCP deployer

### DIFF
--- a/fairing/deployers/gcp/gcp.py
+++ b/fairing/deployers/gcp/gcp.py
@@ -12,37 +12,55 @@ class GCPJob(DeployerInterface):
         project_id: Google Cloud project ID to use.
         region: region in which the job has to be deployed.
             Ref: https://cloud.google.com/compute/docs/regions-zones/
-        scale_tier: machine type to use for the job. 
-            Ref: https://cloud.google.com/ml-engine/docs/tensorflow/machine-types 
+        scale_tier: machine type to use for the job.
+            Ref: https://cloud.google.com/ml-engine/docs/tensorflow/machine-types
+        job_config: Custom job configuration options. If an option is specified
+            in the job_config and as a top-level parameter, the parameter overrides
+            the value in the job_config.
+            Ref: https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs
     """
 
-    def __init__(self, project_id=None, region=None, scale_tier="BASIC"):
+    def __init__(self, project_id=None, region=None, scale_tier=None, job_config=None):
         self._project_id = project_id or guess_project_name()
         self._region = region or 'us-central1'
+        self._job_config = job_config or {}
         self.scale_tier = scale_tier
 
         self._ml = discovery.build('ml', 'v1')
 
-    def deploy(self, pod_template_spec):
-        """Deploys the training job"""
+    def create_request_dict(self, pod_template_spec):
+        """Return the request to be sent to the ML Engine API."""
         # TODO: Update deploy interface to pass image directly instad of
         # PodTemplateSpec.
         # Retrieve image uri from pod template spec.
         image_uri = pod_template_spec.containers[0].image
         self._job_name = 'fairing_job_{}'.format(utils.random_tag())
 
-        request_dict = {
-            'jobId': self._job_name,
-            'trainingInput': {
-                'scaleTier': self.scale_tier,
-                'masterConfig': {
-                    'imageUri': image_uri,
-                },
-                'region': self._region
-            }
-        }
+        # Merge explicitly specified parameters with the job config dictionary
+        request_dict = self._job_config
+        request_dict['jobId'] = self._job_name
+        if 'trainingInput' not in request_dict:
+            request_dict['trainingInput'] = {}
+
+        if self.scale_tier:
+            request_dict['trainingInput']['scaleTier'] = self.scale_tier
+
+        if 'masterConfig' not in request_dict['trainingInput']:
+            request_dict['trainingInput']['masterConfig'] = {}
+        request_dict['trainingInput']['masterConfig']['imageUri'] = image_uri
+
+        if self._region:
+            request_dict['trainingInput']['region'] = self._region
+
+        return request_dict
+
+    def deploy(self, pod_template_spec):
+        """Deploys the training job"""
+        request_dict = self.create_request_dict(pod_template_spec)
 
         try:
+            print('Creating training job with the following options: {}'.format(
+                str(request_dict)))
             response = self._ml.projects().jobs().create(
                 parent='projects/{}'.format(self._project_id),
                 body=request_dict

--- a/tests/unit/deployers/gcp/test_gcp.py
+++ b/tests/unit/deployers/gcp/test_gcp.py
@@ -1,0 +1,100 @@
+import pytest
+import fairing
+
+from kubernetes import client
+from fairing.deployers.gcp.gcp import GCPJob
+
+PROJECT_ID = fairing.cloud.gcp.guess_project_name()
+
+def create_test_pod_spec():
+    return client.V1PodSpec(
+        containers=[client.V1Container(
+            name='model',
+            image='test-image'
+        )]
+    )
+
+def test_default_params():
+    job = GCPJob()
+    request = job.create_request_dict(create_test_pod_spec())
+
+    desired = {
+        'jobId': job._job_name,
+        'trainingInput': {
+            'masterConfig': {
+                'imageUri': 'test-image'
+            },
+            'region': 'us-central1'
+        }
+    }
+
+    assert request == desired
+
+def test_top_level_args():
+    job = GCPJob(region='us-west1', scale_tier='BASIC')
+    request = job.create_request_dict(create_test_pod_spec())
+
+    desired = {
+        'jobId': job._job_name,
+        'trainingInput': {
+            'masterConfig': {
+                'imageUri': 'test-image'
+            },
+            'region': 'us-west1',
+            'scaleTier': 'BASIC'
+        }
+    }
+
+    assert request == desired
+
+def test_custom_job_config():
+    job = GCPJob(job_config={
+        'trainingInput': {
+            'scaleTier': 'CUSTOM',
+            'masterType': 'standard'
+        }
+    })
+    request = job.create_request_dict(create_test_pod_spec())
+
+    desired = {
+        'jobId': job._job_name,
+        'trainingInput': {
+            'masterConfig': {
+                'imageUri': 'test-image'
+            },
+            'region': 'us-central1',
+            'scaleTier': 'CUSTOM',
+            'masterType': 'standard'
+        }
+    }
+
+    assert request == desired
+
+def test_top_level_params_override_job_config():
+    job = GCPJob(region='us-west1', scale_tier='BASIC', job_config={
+        'trainingInput': {
+            'region': 'europe-west1',
+            'scaleTier': 'PREMIUM_1'
+        },
+        'labels': {
+            'test-key': 'test-value'
+        }
+    })
+    request = job.create_request_dict(create_test_pod_spec())
+
+    desired = {
+        'jobId': job._job_name,
+        'trainingInput': {
+            'masterConfig': {
+                'imageUri': 'test-image'
+            },
+            'region': 'us-west1',
+            'scaleTier': 'BASIC'
+        },
+        'labels': {
+            'test-key': 'test-value'
+        }
+    }
+
+    assert request == desired
+


### PR DESCRIPTION
Fixes #161

Add an option for a user-specified request dictionary with configuration options, when submitting jobs using the GCP deployer. This allows users to provide arbitrary job configurations, in addition to those that are exposed as top-level arguments.

Merge strategy: top-level arguments will override corresponding values set in the request dictionary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/172)
<!-- Reviewable:end -->
