### PR TITLE
Add unique label to cluster builder job

### DIFF
--- a/fairing/builders/cluster/cluster.py
+++ b/fairing/builders/cluster/cluster.py
@@ -1,5 +1,5 @@
 import logging
-
+import uuid
 
 from kubernetes import client
 
@@ -63,6 +63,7 @@ class ClusterBuilder(BaseBuilder):
         self.image_tag = self.full_image_name(context_hash)
         self.context_source.prepare(context_path)
         labels = {'fairing-builder': 'kaniko'}
+        labels['fairing-build-id'] = str(uuid.uuid1())
         pod_spec = self.context_source.generate_pod_spec(self.image_tag, self.push)
         for fn in self.pod_spec_mutators:
             fn(self.manager, pod_spec, self.namespace)


### PR DESCRIPTION
We select jobs to retrieve logs for based on labels, so give each build a unique label so we don't accidentally grab an older one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/178)
<!-- Reviewable:end -->
