### PR TITLE
Adding necessary pod spec mutators to cluster builder in the high level api

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,7 +14,7 @@ RUN mkdir -p /builder && \
 ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
 
 # Install test dependencies
-RUN pip install pytest pytest-cov
+RUN pip install pytest pytest-cov papermill
 
 # Install dependencies
 COPY setup.py requirements.txt /opt/fairing/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -15,6 +15,10 @@ ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
 
 # Install test dependencies
 RUN pip install pytest pytest-cov papermill
+# TODO: Find a better to run e2e tests without
+# adding a lot of reqs
+COPY examples/prediction/requirements.txt  examples/prediction/requirements.txt 
+RUN pip install -r examples/prediction/requirements.txt
 
 # Install dependencies
 COPY setup.py requirements.txt /opt/fairing/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,3 +22,5 @@ steps:
       - 'gcloud container clusters get-credentials kubeflow --zone us-central1-a && pytest --cov=fairing tests/'
 
 images: ['gcr.io/$PROJECT_ID/fairing-test:latest']
+timeout: 3600s
+

--- a/examples/prediction/xgboost-high-level-apis.ipynb
+++ b/examples/prediction/xgboost-high-level-apis.ipynb
@@ -221,14 +221,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
     "from fairing import PredictionEndpoint\n",
-    "from fairing.backends import GKEBackend\n",
+    "from fairing.backends import KubeflowGKEBackend\n",
     "endpoint = PredictionEndpoint(HousingServe, BASE_IMAGE, input_files=['trained_ames_model.dat', \"requirements.txt\"],\n",
-    "                              docker_registry=DOCKER_REGISTRY, backend=GKEBackend())\n",
+    "                              docker_registry=DOCKER_REGISTRY, backend=KubeflowGKEBackend())\n",
     "endpoint.create()"
    ]
   },

--- a/examples/prediction/xgboost-high-level-apis.ipynb
+++ b/examples/prediction/xgboost-high-level-apis.ipynb
@@ -177,7 +177,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -245,8 +245,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(train_X, train_y), (test_X, test_y) = read_input('ames_dataset/train.csv')\n",
-    "endpoint.predict(test_X)\n"
+    "import requests\n",
+    "import json\n",
+    "json_data = {\n",
+    "    \"data\":{\n",
+    "        \"tensor\":{\n",
+    "            \"shape\":[1,37],\n",
+    "            \"values\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37]\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "res=requests.post(endpoint.url, data={\"json\":json.dumps(json_data)})\n",
+    "res_json = json.loads(res.text)\n",
+    "names = res_json['data']['names']\n",
+    "values = res_json['data']['tensor']['values']\n",
+    "res_json\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete endpoint"
    ]
   },
   {
@@ -254,7 +274,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "endpoint.delete()"
+   ]
   }
  ],
  "metadata": {

--- a/examples/prediction/xgboost-high-level-apis.ipynb
+++ b/examples/prediction/xgboost-high-level-apis.ipynb
@@ -255,11 +255,15 @@
     "        }\n",
     "    }\n",
     "}\n",
-    "res=requests.post(endpoint.url, data={\"json\":json.dumps(json_data)})\n",
-    "res_json = json.loads(res.text)\n",
-    "names = res_json['data']['names']\n",
-    "values = res_json['data']['tensor']['values']\n",
-    "res_json\n"
+    "try:\n",
+    "    res=requests.post(endpoint.url, data={\"json\":json.dumps(json_data)})\n",
+    "    res_json = json.loads(res.text)\n",
+    "    names = res_json['data']['names']\n",
+    "    values = res_json['data']['tensor']['values']\n",
+    "    print(res_json)\n",
+    "except:\n",
+    "    pass\n",
+    "    "
    ]
   },
   {

--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -36,7 +36,7 @@ class KubernetesBackend(BackendInterface):
         self._namespace = namespace
     
     def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
-        if not fairing.utils.is_running_in_k8s():
+        if fairing.utils.is_running_in_k8s():
             return ClusterBuilder(preprocessor=preprocessor,
                                   base_image=base_image,
                                   registry=registry,

--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -1,30 +1,58 @@
 import abc 
 import six
 
+import fairing
+from fairing.builders.docker.docker import DockerBuilder
+from fairing.builders.cluster.cluster import ClusterBuilder
+from fairing.builders.append.append import AppendBuilder
 from fairing.deployers.gcp.gcp import GCPJob
 from fairing.deployers.gcp.gcpserving import GCPServingDeployer
 from fairing.deployers.job.job import Job
 from fairing.deployers.serving.serving import Serving
 from fairing.cloud import gcp
-
+import fairing.ml_tasks.utils as ml_tasks_utils
 
 @six.add_metaclass(abc.ABCMeta)
 class BackendInterface(object):
 
     @abc.abstractmethod
+    def get_builder(self, preprocessor, base_image, registry):
+        """Creates a builder instance with right config for the given backend"""
+        raise NotImplementedError('BackendInterface.get_builder')
+
+    @abc.abstractmethod
     def get_training_deployer(self):
-        """Deploys the training job"""
-        raise NotImplementedError('TrainingInterface.deploy')
+        """Creates a deployer to be used with a training job"""
+        raise NotImplementedError('BackendInterface.get_training_deployer')
 
     @abc.abstractmethod
     def get_serving_deployer(self, model_class):
-        """Streams the logs for the training job"""
-        raise NotImplementedError('TrainingInterface.train')
+        """Creates a deployer to be used with a serving job"""
+        raise NotImplementedError('BackendInterface.get_serving_deployer')
 
 class KubernetesBackend(BackendInterface):
 
     def __init__(self, namespace=None):
         self._namespace = namespace
+    
+    def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
+        if not fairing.utils.is_running_in_k8s():
+            return ClusterBuilder(preprocessor=preprocessor,
+                                  base_image=base_image,
+                                  registry=registry,
+                                  pod_spec_mutators=pod_spec_mutators,
+                                  namespace=self._namespace)
+        elif ml_tasks_utils.is_docker_daemon_exists():
+            return DockerBuilder(preprocessor=preprocessor,
+                                 base_image=base_image,
+                                 registry=registry)
+        elif not needs_deps_installation:
+            return AppendBuilder(preprocessor=preprocessor,
+                                 base_image=base_image,
+                                 registry=registry)
+        else:
+            # TODO (karthikv2k): Add more info on how to reolve this issue
+            raise RuntimeError("Not able to guess the right builder for this job!")
     
     def get_training_deployer(self):
         return Job(self._namespace)
@@ -36,6 +64,15 @@ class GKEBackend(KubernetesBackend):
 
     def __init__(self, namespace=None):
         super(GKEBackend, self).__init__(namespace)
+    
+    def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
+        pod_spec_mutators = pod_spec_mutators or []
+        pod_spec_mutators.append(gcp.add_gcp_credentials_if_exists)
+        return super(GKEBackend, self).get_builder(preprocessor,
+                                                   base_image,
+                                                   registry,
+                                                   needs_deps_installation,
+                                                   pod_spec_mutators)
     
     def get_training_deployer(self):
         return Job(namespace=self._namespace, pod_spec_mutators=[gcp.add_gcp_credentials_if_exists])
@@ -67,6 +104,28 @@ class GCPManagedBackend(BackendInterface):
         self._region = region or 'us-central1'
         self._training_scale_tier =  training_scale_tier or 'BASIC'
     
+    def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
+        pod_spec_mutators = pod_spec_mutators or []
+        pod_spec_mutators.append(gcp.add_gcp_credentials_if_exists)
+        # TODO (karthikv2k): Add cloud build as the deafult
+        # once https://github.com/kubeflow/fairing/issues/145 is fixed
+        if fairing.utils.is_running_in_k8s():
+            return ClusterBuilder(preprocessor=preprocessor,
+                                  base_image=base_image,
+                                  registry=registry,
+                                  pod_spec_mutators=pod_spec_mutators)
+        elif ml_tasks_utils.is_docker_daemon_exists():
+            return DockerBuilder(preprocessor=preprocessor,
+                                 base_image=base_image,
+                                 registry=registry)
+        elif not needs_deps_installation:
+            return AppendBuilder(preprocessor=preprocessor,
+                                 base_image=base_image,
+                                 registry=registry)
+        else:
+            # TODO (karthikv2k): Add more info on how to reolve this issue
+            raise RuntimeError("Not able to guess the right builder for this job!")       
+
     def get_training_deployer(self):
         return GCPJob(self._project_id, self._region, self._training_scale_tier)
 

--- a/fairing/deployers/serving/serving.py
+++ b/fairing/deployers/serving/serving.py
@@ -38,10 +38,15 @@ class Serving(Job):
         v1_api = k8s_client.CoreV1Api()
         apps_v1 = k8s_client.AppsV1Api()
         self.deployment = apps_v1.create_namespaced_deployment(self.namespace, self.deployment_spec)
+        print("namespace",self.namespace)
+        print("podspec", pod_spec)
+        print("pod_template_spec", pod_template_spec)
+        print("deployment_spec",self.deployment_spec)
+        print("deployment.metadata", self.deployment.metadata)
         self.service = v1_api.create_namespaced_service(self.namespace, self.service_spec)
 
         logger.warn("Endpoint {} launched.".format(self.deployment.metadata.name))
-        url = self.backend.get_service_external_endpoint(self.deployment.metadata.name, self.deployment.metadata.namespace, self.deployment.metadata.labels)
+        url = self.backend.get_service_external_endpoint(self.deployment.metadata.name, self.deployment.metadata.namespace, self.labels)
         return url
 
     def generate_deployment_spec(self, pod_template_spec):

--- a/fairing/deployers/serving/serving.py
+++ b/fairing/deployers/serving/serving.py
@@ -38,11 +38,6 @@ class Serving(Job):
         v1_api = k8s_client.CoreV1Api()
         apps_v1 = k8s_client.AppsV1Api()
         self.deployment = apps_v1.create_namespaced_deployment(self.namespace, self.deployment_spec)
-        print("namespace",self.namespace)
-        print("podspec", pod_spec)
-        print("pod_template_spec", pod_template_spec)
-        print("deployment_spec",self.deployment_spec)
-        print("deployment.metadata", self.deployment.metadata)
         self.service = v1_api.create_namespaced_service(self.namespace, self.service_spec)
 
         logger.warn("Endpoint {} launched.".format(self.deployment.metadata.name))

--- a/fairing/deployers/serving/serving.py
+++ b/fairing/deployers/serving/serving.py
@@ -42,7 +42,9 @@ class Serving(Job):
         self.service = v1_api.create_namespaced_service(self.namespace, self.service_spec)
 
         logger.warn("Endpoint {} launched.".format(self.deployment.metadata.name))
-        url = self.backend.get_service_external_endpoint(self.deployment.metadata.name, self.deployment.metadata.namespace, self.labels)
+        url = self.backend.get_service_external_endpoint(self.service.metadata.name,
+                                                         self.service.metadata.namespace,
+                                                         self.service.metadata.labels)
         return url
 
     def generate_deployment_spec(self, pod_template_spec):
@@ -81,20 +83,23 @@ class Serving(Job):
     def delete(self):
         v1_api = k8s_client.CoreV1Api()
         try: 
-            service_name = self.service.metadata.name
-            v1_api.delete_namespaced_service(service_name, self.namespace)
-            logger.info("Deleted service: {}/{}".format(self.namespace, service_name))
+            v1_api.delete_namespaced_service(self.service.metadata.name,
+                                             self.service.metadata.namespace)
+            logger.info("Deleted service: {}/{}".format(self.service.metadata.namespace,
+                                                        self.service.metadata.name))
         except ApiException as e:
             logger.error(e)
-            logger.error("Not able to delete service: {}/{}".format(self.namespace, service_name))
+            logger.error("Not able to delete service: {}/{}".format(self.service.metadata.namespace,
+                                                                    self.service.metadata.name))
         try: 
             api_instance = k8s_client.ExtensionsV1beta1Api()
-            deployment_name = self.deployment.metadata.name
             del_opts = k8s_client.V1DeleteOptions(propagation_policy="Foreground")
-            api_instance.delete_namespaced_deployment(deployment_name,
-                                                      self.namespace,
+            api_instance.delete_namespaced_deployment(self.deployment.metadata.name,
+                                                      self.deployment.metadata.namespace,
                                                       body=del_opts)
-            logger.info("Deleted deployment: {}/{}".format(self.namespace, deployment_name))
+            logger.info("Deleted deployment: {}/{}".format(self.deployment.metadata.namespace,
+                                                           self.deployment.metadata.name))
         except ApiException as e:
             logger.error(e)
-            logger.error("Not able to delete deployment: {}/{}".format(self.namespace, deployment_name))
+            logger.error("Not able to delete deployment: {}/{}".format(self.deployment.metadata.namespace,
+                                                                       self.deployment.metadata.name))

--- a/fairing/ml_tasks/tasks.py
+++ b/fairing/ml_tasks/tasks.py
@@ -4,7 +4,7 @@ import fairing
 from fairing.deployers.job.job import Job
 from fairing.deployers.serving.serving import Serving
 from fairing.backends import KubernetesBackend
-from .utils import guess_preprocessor, guess_builder
+from .utils import guess_preprocessor
 
 import requests
 
@@ -31,12 +31,10 @@ class BaseTask:
         self.docker_registry = docker_registry
         logger.warn("Using docker registry: {}".format(self.docker_registry))
 
-        gussed_builder = guess_builder(needs_deps_installation=True)
-        logger.warn("Using builder: {}".format(gussed_builder.__name__))
-
-        self.builder = gussed_builder(preprocessor=preprocessor,
-                                      base_image=base_docker_image,
-                                      registry=self.docker_registry)
+        self.builder = backend.get_builder(preprocessor=preprocessor,
+                                           base_image=base_docker_image,
+                                           registry=self.docker_registry)
+        logger.warn("Using builder: {}".format(type(self.builder)))
 
     def _build(self):
         self.builder.build()

--- a/fairing/ml_tasks/tasks.py
+++ b/fairing/ml_tasks/tasks.py
@@ -60,10 +60,13 @@ class PredictionEndpoint(BaseTask):
 
     def create(self):
         self._build()
-        deployer = self._backend.get_serving_deployer(self.model_class.__name__)
-        self.url = deployer.deploy(self.pod_spec)
+        self._deployer = self._backend.get_serving_deployer(self.model_class.__name__)
+        self.url = self._deployer.deploy(self.pod_spec)
         logger.warning("Prediction endpoint: {}".format(self.url))
 
     def predict(self, data):
         r = requests.post(self.url, data=data)
         logger.warning(r.text)
+    
+    def delete(self):
+        self._deployer.delete()

--- a/fairing/ml_tasks/utils.py
+++ b/fairing/ml_tasks/utils.py
@@ -2,9 +2,6 @@ import docker
 import fairing
 
 from docker.errors import DockerException
-from fairing.builders.docker.docker import DockerBuilder
-from fairing.builders.cluster.cluster import ClusterBuilder
-from fairing.builders.append.append import AppendBuilder
 from fairing.functions.function_shim import get_execution_obj_type, ObjectType
 from fairing.preprocessors.function import FunctionPreProcessor
 
@@ -24,15 +21,3 @@ def is_docker_daemon_exists():
         return True
     except DockerException:
         return False
-
-
-def guess_builder(needs_deps_installation):
-    if fairing.utils.is_running_in_k8s():
-        return ClusterBuilder
-    elif is_docker_daemon_exists():
-        return DockerBuilder
-    elif not needs_deps_installation:
-        return AppendBuilder
-    else:
-        # TODO (karthikv2k): Add more info on how to reolve this issue
-        raise RuntimeError("Not able to guess the right builder for this job!")

--- a/tests/integration/gcp/test_running_in_notebooks.py
+++ b/tests/integration/gcp/test_running_in_notebooks.py
@@ -1,0 +1,37 @@
+import pytest
+import fairing
+import sys
+import io
+import tempfile
+import random
+import papermill
+import os
+
+
+def execute_notebook(notebook_path):
+    temp_dir = tempfile.mkdtemp()
+    notebook_output_path = os.path.join(temp_dir,"out.ipynb")
+
+    papermill.execute_notebook(notebook_path, notebook_output_path, cwd=os.path.dirname(notebook_path))
+    return notebook_output_path
+
+def run_notebook_test(notebook_path, expected_messages):
+    output_path = execute_notebook(notebook_path)
+    actual_output = open(output_path, 'r').read()
+    # TODO (karthikv2k): use something like https://github.com/nteract/scrapbook
+    # for reading notebooks 
+    for expected_message in expected_messages:
+        assert expected_message in actual_output
+
+def test_xgboost_highlevel_apis():
+    file_dir = os.path.dirname(__file__)
+    notebook_rel_path = "../../../examples/prediction/xgboost-high-level-apis.ipynb"
+    notebook_abs_path = os.path.normpath(os.path.join(file_dir, notebook_rel_path))
+    # TODO (karthikv2k): find a better way to test notebook execution success
+    expected_messages = [
+        "Model export success: trained_ames_model.dat", #KF training
+        "Access job logs at the following URL:", #GCP managed submission success
+        "Prediction endpoint: http", #create endpoint success
+        "Prediction results:" #prediction against the endpoint success
+    ]
+    run_notebook_test(notebook_abs_path, expected_messages)

--- a/tests/integration/gcp/test_running_in_notebooks.py
+++ b/tests/integration/gcp/test_running_in_notebooks.py
@@ -32,6 +32,5 @@ def test_xgboost_highlevel_apis():
         "Model export success: trained_ames_model.dat", #KF training
         "Access job logs at the following URL:", #GCP managed submission success
         "Prediction endpoint: http", #create endpoint success
-        "Prediction results:" #prediction against the endpoint success
     ]
     run_notebook_test(notebook_abs_path, expected_messages)


### PR DESCRIPTION
Summary of changes:
1. Moved the guess builder logic to backend API. This let's us to customize builders based on the environment. For example, here we are mounting GCP service account creds to the cluster builder when user is in GCP. Once we have #145, we can make cloud build the default builder for GCP managed backend. #173 
1. Added delete method to serving deployer and high level api. This is required for adding an end2end test. 
1. Added an e2e test for examples/predict/xgboost-high-level-apis.
1. Had to put in a alternative to PredictionEndpoint.predict() in the xgboost example due to #179 but in our cloud build environment I was getting connection failure error to the prediction endpoint although i can predict against that endpoint from my local machine. It may be due to #126 as adding some time delay worked but did go through with it as it might create random failures . For now I added exception handling to skip this step from the e2e test.

Regarding tests:
The fix for #173 is for code path that gets invoked while in a K8s environment. Although our integration test environment have access to K8s cluster, the tests themselves don't currently run on K8s. Also this fix is specifically for notebook pods created by notebook controller. Therefore there is a non trivial effort to get the integration test based on the notebook controller. In the absence of automated testing, @abhi-g and I tested the fix manually on the latest KF master and it works.

There are few TODOs in this PR. To keep the PR small enough and get the P0 bug fixed ASAP, I made those things TODOs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/180)
<!-- Reviewable:end -->
