### PR TITLE
Test improvements and minor fixes for storage client auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.DS_Store

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.7
 
 WORKDIR /opt/fairing
 ARG CLOUD_SDK_VERSION="236.0.0"

--- a/fairing/cloud/gcp.py
+++ b/fairing/cloud/gcp.py
@@ -15,8 +15,7 @@ class GCSUploader(object):
     def __init__(
             self,
             credentials_file=os.environ.get(constants.GOOGLE_CREDS_ENV)):
-        self.storage_client = storage. \
-            Client.from_service_account_json(credentials_file)
+        self.storage_client = storage.Client()
 
     def upload_to_bucket(self,
                          blob_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ oauth2client>=4.0.0
 tornado>=5.1.1,<6.0.0
 google-api-python-client>=1.7.8
 cloudpickle>=0.8
+numpy>=1.14

--- a/tests/integration/common/test_kubeflow_training.py
+++ b/tests/integration/common/test_kubeflow_training.py
@@ -4,6 +4,8 @@ import sys
 import io
 import tempfile
 import random
+import time
+import uuid
 
 from google.cloud import storage
 from fairing import TrainJob
@@ -12,35 +14,42 @@ from fairing.backends import KubeflowGKEBackend, GKEBackend, GCPManagedBackend
 
 GCS_PROJECT_ID = fairing.cloud.gcp.guess_project_name()
 DOCKER_REGISTRY = 'gcr.io/{}'.format(GCS_PROJECT_ID)
-DUMMY_FN_MSG = "hello world"
 
 # Dummy training function to be submitted
-def train_fn():
-    print(DUMMY_FN_MSG)
+def train_fn(msg):
+    for _ in range(30):
+        time.sleep(0.1)
+        print(msg)
 
 # Update module to work with function preprocessor
 # TODO: Remove when the function preprocessor works with functions from
 # other modules.
 train_fn.__module__ = '__main__'
 
-def run_submission_with_function_preprocessor(capsys, expected_result, deployer="job", builder="append", namespace="default"):
-    base_image = 'gcr.io/{}/fairing-test:latest'.format(GCS_PROJECT_ID)
-    fairing.config.set_builder('append', base_image=base_image, registry=DOCKER_REGISTRY)
+def run_submission_with_function_preprocessor(capsys, deployer="job", builder="append", namespace="default"):
+    py_version = ".".join([str(x) for x in sys.version_info[0:3]])
+    base_image = 'registry.hub.docker.com/library/python:{}'.format(py_version)
+    if builder=='cluster':
+        fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY,
+                                   pod_spec_mutators=[fairing.cloud.gcp.add_gcp_credentials])
+    else:
+        fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY)
     fairing.config.set_deployer(deployer, namespace=namespace)
 
-    remote_train = fairing.config.fn(train_fn)
+    expected_result = str(uuid.uuid4())
+    remote_train = fairing.config.fn(lambda : train_fn(expected_result))
     remote_train()
     captured = capsys.readouterr()
     assert expected_result in captured.out
 
 def test_job_deployer(capsys):
-    run_submission_with_function_preprocessor(capsys, DUMMY_FN_MSG, deployer="job")    
+    run_submission_with_function_preprocessor(capsys, deployer="job")    
 
 def test_tfjob_deployer(capsys):
-    run_submission_with_function_preprocessor(capsys, DUMMY_FN_MSG, deployer="tfjob", namespace="kubeflow") 
+    run_submission_with_function_preprocessor(capsys, deployer="tfjob", namespace="kubeflow") 
 
 def test_docker_builder(capsys):
-    run_submission_with_function_preprocessor(capsys, DUMMY_FN_MSG, builder="docker")    
+    run_submission_with_function_preprocessor(capsys, builder="docker")    
 
 def test_cluster_builder(capsys):
-    run_submission_with_function_preprocessor(capsys, DUMMY_FN_MSG, builder="cluster", namespace="kubeflow")
+    run_submission_with_function_preprocessor(capsys, builder="cluster", namespace="kubeflow")


### PR DESCRIPTION
Summary:
1. A lot of tests were using constant message that might lead to false positives where a cached output makes the test pass. So I made the test messages to be UUIDs to make tests robust. Additionally, added some delays to print test messages to avoid test flakiness in case of very short lived jobs.
2. GCP Storage client was expecting a service account key and this was breaking in environments where application default credentials are used like GCE instances. So I made it to use underlying auth lib to figure out credential instead of requiring json key.
3. Fixes #183 
4. Updated python version used for tests to 3.7. Seldon only supports 3.6+ so it is better to update the version.
5. Changed base image used in tests to plain python images. This increases isolation between tests. Currently we use images that are built from previous tests runs that is causing unwanted dependencies.
6. Fixed a bug in the tests for docker and cluster builder where append builder was used instead of docker and cluster builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/187)
<!-- Reviewable:end -->
