### PR TITLE
Making tests run parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 # Python versions to test
 python:
-    - "3.5"
+    - "3.7"
 # Command to install dependencies
 install:
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial # required for Python >= 3.7
 language: python
 # Python versions to test
 python:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,7 +14,7 @@ RUN mkdir -p /builder && \
 ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
 
 # Install test dependencies
-RUN pip install pytest pytest-cov papermill
+RUN pip install pytest pytest-cov pytest-xdist papermill
 # TODO: Find a better to run e2e tests without
 # adding a lot of reqs
 COPY examples/prediction/requirements.txt  examples/prediction/requirements.txt 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,10 +17,10 @@ steps:
 # Authenticate with Kubeflow cluster and run tests
 - name: 'gcr.io/$PROJECT_ID/fairing-test:latest'
   entrypoint: 'bash'
-  args:
+  args: 
       - '-c'
-      - 'gcloud container clusters get-credentials kubeflow --zone us-central1-a && pytest --cov=fairing tests/'
+      - 'gcloud container clusters get-credentials kubeflow --zone us-central1-a && pytest -n 32 -v --durations=10 --cov=fairing tests/'
 
 images: ['gcr.io/$PROJECT_ID/fairing-test:latest']
-timeout: 3600s
+timeout: 3600s 
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,8 +19,9 @@ steps:
   entrypoint: 'bash'
   args: 
       - '-c'
-      - 'gcloud container clusters get-credentials kubeflow --zone us-central1-a && pytest -n 32 -v --durations=10 --cov=fairing tests/'
+      - 'gcloud container clusters get-credentials kubeflow --zone us-central1-a && pytest -n 8 -v --durations=10 --cov=fairing tests/'
 
 images: ['gcr.io/$PROJECT_ID/fairing-test:latest']
 timeout: 3600s 
-
+options:
+  machineType: 'N1_HIGHCPU_8'

--- a/fairing/builders/dockerfile.py
+++ b/fairing/builders/dockerfile.py
@@ -1,15 +1,18 @@
 from fairing.constants import constants
 import logging
+import tempfile
 logger = logging.getLogger('fairing')
 
 # TODO(@karthikv2k): Need to be refractored into a better template
 def write_dockerfile(
         docker_command=None,
-        destination=constants.DEFAULT_GENERATED_DOCKERFILE_FILENAME,
+        destination=None,
         path_prefix=constants.DEFAULT_DEST_PREFIX,
         dockerfile_path=None,
         base_image=None,
         install_reqs_before_copy=False):
+    if not destination:
+        _, destination = tempfile.mkstemp(prefix="/tmp/fairing_dockerfile_")
     content_lines = [ "FROM {}".format(base_image),
         "WORKDIR {PATH_PREFIX}".format(PATH_PREFIX=path_prefix),
         "ENV FAIRING_RUNTIME 1"]

--- a/fairing/preprocessors/base.py
+++ b/fairing/preprocessors/base.py
@@ -8,7 +8,7 @@ import tarfile
 import glob
 import logging
 import posixpath
-
+import tempfile
 
 class BasePreProcessor(object):
     """
@@ -83,7 +83,9 @@ class BasePreProcessor(object):
 
         return c_map
 
-    def context_tar_gz(self, output_file=constants.DEFAULT_CONTEXT_FILENAME):
+    def context_tar_gz(self, output_file=None):
+        if not output_file:
+            _, output_file = tempfile.mkstemp(prefix="/tmp/fairing_context_")
         logging.info("Creating docker context: %s", output_file)
         self.input_files = self.preprocess()
         with tarfile.open(output_file, "w:gz", dereference=True) as tar:

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,0 +1,1 @@
+workflows: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
+requests>=2.21.0
 docker>=3.4.1
 notebook>=5.6.0
 kubernetes>=9.0.0
 future>=0.17.1
 six>=1.11.0
 google-cloud-storage>=1.13.2
-requests>=2.21.0
 setuptools>=34.0.0
 google-auth>=1.6.2
 httplib2>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-requests>=2.21.0
 docker>=3.4.1
 notebook>=5.6.0
 kubernetes>=9.0.0
 future>=0.17.1
 six>=1.11.0
 google-cloud-storage>=1.13.2
+requests>=2.21.0
 setuptools>=34.0.0
 google-auth>=1.6.2
 httplib2>=0.12.0
@@ -13,3 +13,4 @@ tornado>=5.1.1,<6.0.0
 google-api-python-client>=1.7.8
 cloudpickle>=0.8
 numpy>=1.14
+urllib3==1.24.2


### PR DESCRIPTION
Fixes #213 
This reduces test run time from 20-21 mins to 6-7 mins in cloud build including the cloud build start up time. 

Changes summary:
1. Made the preprocessor output file random instead of a constant. This make is possible to run multiple fairing jobs in parallel in an instance. This is useful for users who are launching multiple jobs in different notebooks in the same instance and also for tests.
2. Bumping up the python version in travis to match post commit test python version
3. Printing top 10 slowest test for improving test run times
4. Moved requests lib to the top of requirements.txt to resolve some deps mismatch issue
5. Using machine type with 8 vCPUs for post commit test. Test machine type with 32 vCPUs (only other choice) but didn't improve the test times considerably.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/218)
<!-- Reviewable:end -->
