### PR TITLE
Updating gsutil config to improve speed

### DIFF
--- a/examples/lightgbm/Dockerfile
+++ b/examples/lightgbm/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 RUN mkdir -p /opt/fairing
 WORKDIR /opt/fairing
-ARG CLOUD_SDK_VERSION="236.0.0"
+ARG CLOUD_SDK_VERSION="248.0.0"
 
 # Install pinned version of gcloud
 RUN mkdir -p /builder && \
@@ -12,13 +12,18 @@ RUN mkdir -p /builder && \
 		--disable-installation-options && \
 	rm -rf ~/.config/gcloud && \
     # to make gsutil use the service account
-    echo "[Credentials]\ngs_service_key_file = /etc/secrets/user-gcp-sa.json" > /etc/boto.cfg
+    echo "[Credentials]\ngs_service_key_file = /etc/secrets/user-gcp-sa.json" > /etc/boto.cfg && \
+    # optimal settings for faster download speed
+    echo "[GSUtil]\nparallel_process_count=4\nparallel_thread_count=1" >> /etc/boto.cfg
 
 ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
 
 RUN apt-get update && \
-    apt-get install -y cmake build-essential gcc g++ git wget && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y cmake build-essential gcc g++ git wget python-dev python-setuptools python-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    #https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod	
+    #crcmod is used to speed up downloads	
+    python2 -m pip install --no-cache-dir -U crcmod
 
 RUN git clone --recursive --branch stable https://github.com/Microsoft/LightGBM && \
     mkdir LightGBM/build && \


### PR DESCRIPTION
With parallel downloads and crcmod, the download speed increased by 4x. In my tests on n1-highmem-624 instances, I was getting around 300-350 MBps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/264)
<!-- Reviewable:end -->
