### PR TITLE
Support hostname as a serving endpoint

### DIFF
--- a/fairing/kubernetes/manager.py
+++ b/fairing/kubernetes/manager.py
@@ -76,7 +76,7 @@ class KubeManager(object):
                              event['object'])
                 ing = svc.status.load_balancer.ingress
                 if ing is not None and len(ing) > 0:
-                    url = "http://{}:5000/predict".format(ing[0].ip)
+                    url = "http://{}:5000/predict".format(ing[0].ip or ing[0].hostname)
                     return url
         except ValueError as v:
             logger.error("error getting status for {} {}".format(name, str(v)))


### PR DESCRIPTION
Some LB-controller implementation (like ELB) returns not ip but hostname.
This patch adds support of hostname as serving endpoint url.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/266)
<!-- Reviewable:end -->
