### PR TITLE
LightGBM - Copies weight file if it exists

### DIFF
--- a/fairing/cloud/storage.py
+++ b/fairing/cloud/storage.py
@@ -1,0 +1,74 @@
+import six
+import abc
+from google.cloud import storage
+from urllib.parse import urlparse
+
+def lookup_storage_class(url):
+    scheme = urlparse(url).scheme
+    if scheme in ["gcs", "gs"]:
+        return GCSStorage
+    else:
+        return None
+
+def get_storage_class(url):
+    res = lookup_storage_class(url)
+    if res:
+        return res
+    else:
+        raise RuntimeError(
+            "can't find a suitable storage class for {}".format(url))
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Storage:
+
+    # Using shell commands to do the file copy instead of using python libs
+    # CLIs like gsutil, s3cmd are optimized and can be easily configured by
+    # the user using boto.cfg in the base docker image.
+    @abc.abstractmethod
+    def copy_cmd(self, src_url, dst_url, recursive=True):
+        """gets a command to copy files from/to remote storage from/to local FS"""
+        raise NotImplementedError('Storage.copy_cmd')
+
+    @abc.abstractmethod
+    def exists(self, url):
+        """checks if the url exists in the given storage"""
+        raise NotImplementedError('Storage.exists')
+
+
+class GCSStorage(Storage):
+
+    def __init__(self):
+        self.client = storage.Client()
+
+    def copy_cmd(self, src_url, dst_url, recursive=True):
+        if recursive:
+            rcmd = "-r"
+        else:
+            rcmd = ""
+        return "gsutil cp {} {} {}".format(rcmd, src_url, dst_url)
+
+    @classmethod
+    def _check_prefix(cls, bucket, prefix):
+        # url points to a dir like resource
+        # Checking if at least one blob exists
+        blobs = [x for x in bucket.list_blobs(prefix=prefix, max_results=1)]
+        if len(blobs) == 1:
+            return True
+        return False
+
+    def exists(self, url):
+        url_parts = urlparse(url)
+        bucket_name = url_parts.netloc
+        bucket = self.client.bucket(bucket_name)
+        if not url_parts.path or url_parts.path == "/":
+            return True
+        if bucket:
+            prefix_key = url_parts.path[1:]
+            if prefix_key.endswith("/"):
+                return GCSStorage._check_prefix(bucket, prefix_key)
+            elif bucket.get_blob(prefix_key):
+                return True
+            else:
+                return GCSStorage._check_prefix(bucket, prefix_key + "/")
+        return False

--- a/tests/integration/gcp/test_running_in_notebooks.py
+++ b/tests/integration/gcp/test_running_in_notebooks.py
@@ -41,6 +41,7 @@ def test_lightgbm():
     notebook_abs_path = os.path.normpath(os.path.join(file_dir, notebook_rel_path))
     # TODO (karthikv2k): find a better way to test notebook execution success
     expected_messages = [
+        "Copying gs://fairing-lightgbm/regression-example/regression.train.weight",
         "[LightGBM] [Info] Finished initializing network", #dist training setup
         "[LightGBM] [Info] Iteration:10, valid_1 l2 : 0.2",
         "[LightGBM] [Info] Finished training",

--- a/tests/unit/frameworks/test_lightgbm.py
+++ b/tests/unit/frameworks/test_lightgbm.py
@@ -3,6 +3,7 @@ from fairing.frameworks import lightgbm
 import fairing
 import posixpath
 from fairing.constants import constants
+from unittest.mock import patch
 
 EXAMPLE_CONFIG = {
     'task': 'train',
@@ -20,8 +21,9 @@ EXMAPLE_CONFIG_FILE_NAME = "/config-file.conf"
 
 
 def test_context_files_list():
-    output_map = lightgbm.generate_context_files(
-        EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+    with patch('fairing.cloud.storage.GCSStorage.exists'):
+        output_map = lightgbm.generate_context_files(
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
     actual = list(output_map.values())
     actual.sort()
     expected = [
@@ -35,8 +37,9 @@ def test_context_files_list():
 
 
 def test_context_files_list_dist():
-    output_map = lightgbm.generate_context_files(
-        EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, True)
+    with patch('fairing.cloud.storage.GCSStorage.exists'):
+        output_map = lightgbm.generate_context_files(
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, True)
     actual = list(output_map.values())
     actual.sort()
     expected = [
@@ -51,8 +54,9 @@ def test_context_files_list_dist():
 
 
 def test_entrypoint_content():
-    output_map = lightgbm.generate_context_files(
-        EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+    with patch('fairing.cloud.storage.GCSStorage.exists'):
+        output_map = lightgbm.generate_context_files(
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
     entrypoint_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'entrypoint.sh')
     entrypoint_file = None
     for k, v in output_map.items():
@@ -61,18 +65,20 @@ def test_entrypoint_content():
     actual = open(entrypoint_file, "r").read()
     expected = """#!/bin/sh
 set -e
-gsutil cp gs://lightgbm-test/regression.train {0}/regression.train
-gsutil cp gs://lightgbm-test/regression.test {0}/regression.test
+gsutil cp -r gs://lightgbm-test/regression.train.weight {0}/regression.train.weight
+gsutil cp -r gs://lightgbm-test/regression.train {0}/regression.train
+gsutil cp -r gs://lightgbm-test/regression.test {0}/regression.test
 echo 'All files are copied!'
 lightgbm config={0}/config.conf
-gsutil cp {0}/model.txt gs://lightgbm-test/model.txt
+gsutil cp -r {0}/model.txt gs://lightgbm-test/model.txt
 """.format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
     print(actual)
     assert actual == expected
 
 def test_final_config():
-    output_map = lightgbm.generate_context_files(
-        EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+    with patch('fairing.cloud.storage.GCSStorage.exists'):
+        output_map = lightgbm.generate_context_files(
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
     config_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'config.conf')
     config_file_local = None
     for k, v in output_map.items():
@@ -88,6 +94,35 @@ valid_data={0}/regression.test
 train_data={0}/regression.train
 verbose=1
 model_output={0}/model.txt
+""".format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
+    print(actual)
+    assert actual == expected
+
+def test_input_file_not_found():    
+    with pytest.raises(RuntimeError) as excinfo:
+        with patch('fairing.cloud.storage.GCSStorage.exists', new=lambda x, y: False):
+            _ = lightgbm.generate_context_files(
+                    EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+    err_msg = str(excinfo.value)
+    assert "Remote file " in err_msg and "does't exist" in err_msg
+
+def test_entrypoint_content_no_weight_file():
+    with patch('fairing.cloud.storage.GCSStorage.exists', new=lambda bucket,path: not path.endswith(".weight")):
+        output_map = lightgbm.generate_context_files(
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+    entrypoint_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'entrypoint.sh')
+    entrypoint_file = None
+    for k, v in output_map.items():
+        if v == entrypoint_file_in_docker:
+            entrypoint_file = k
+    actual = open(entrypoint_file, "r").read()
+    expected = """#!/bin/sh
+set -e
+gsutil cp -r gs://lightgbm-test/regression.train {0}/regression.train
+gsutil cp -r gs://lightgbm-test/regression.test {0}/regression.test
+echo 'All files are copied!'
+lightgbm config={0}/config.conf
+gsutil cp -r {0}/model.txt gs://lightgbm-test/model.txt
 """.format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
     print(actual)
     assert actual == expected


### PR DESCRIPTION
Summary:
1. LightGBM uses .weight file automatically if it exists so to keep the behavior same, .weight file copied from GCS if it exists. https://lightgbm.readthedocs.io/en/latest/Parameters.html#weight-data 
1. Refactored storage utils and created an abstraction to support storage systems other than GCS
1. Added unit tests
1. Created and uploaded .weight file for the integration test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/267)
<!-- Reviewable:end -->
