### PR TITLE
Added support for data parallel mode in LightGBM

### DIFF
--- a/examples/lightgbm/distributed-training-data-parallel.ipynb
+++ b/examples/lightgbm/distributed-training-data-parallel.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A simple regression training using LightGBM through Fairing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from time import gmtime, strftime\n",
+    "import fairing\n",
+    "from fairing.frameworks import lightgbm\n",
+    "\n",
+    "# Setting up google container repositories (GCR) for storing output containers\n",
+    "# You can use any docker container registry istead of GCR\n",
+    "GCP_PROJECT = fairing.cloud.gcp.guess_project_name()\n",
+    "DOCKER_REGISTRY = 'gcr.io/{}/fairing-job'.format(GCP_PROJECT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Launch a LightGBM train task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Creating a bucket for copying the trained model. \n",
+    "# You can set gcs_bucket variable to an existing bucket name if that is desired.\n",
+    "gcs_bucket = \"gs://{}-fairing\".format(GCP_PROJECT)\n",
+    "!gsutil mb {gcs_bucket}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data parallel training\n",
+    "LightGBM supports many parallel trianing methods. One of them is data parallel mode where the training data \n",
+    "is partitioned and each partition is copied to workers. This is useful for training large datasets.\n",
+    "For more information please read LightGBM parallel guide. \n",
+    "https://github.com/microsoft/LightGBM/blob/master/docs/Parallel-Learning-Guide.rst"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partitioned_train_data = !gsutil ls gs://fairing-lightgbm/regression-example-dist/\n",
+    "partitioned_train_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = {\n",
+    "    'task': 'train',\n",
+    "    'boosting_type': 'gbdt',\n",
+    "    'objective': 'regression',\n",
+    "    'metric': 'l2',\n",
+    "    'metric_freq': 1,\n",
+    "    'num_leaves': 31,\n",
+    "    'learning_rate': 0.05,\n",
+    "    'feature_fraction': 0.9,\n",
+    "    'bagging_fraction': 0.8,\n",
+    "    'bagging_freq': 5,\n",
+    "    \"n_estimators\": 10,\n",
+    "    \"is_training_metric\": \"true\",\n",
+    "    \"valid_data\": \"gs://fairing-lightgbm/regression-example/regression.test\",\n",
+    "    \"train_data\": \",\".join(partitioned_train_data),\n",
+    "    'verbose': 1,\n",
+    "    \"verbose_eval\": 1,\n",
+    "    \"model_output\": \"{}/lightgbm/example/model_{}.txt\".format(gcs_bucket, strftime(\"%Y_%m_%d_%H_%M_%S\", gmtime())),\n",
+    "    \"num_machines\": 4,\n",
+    "    \"tree_learner\": \"data\"\n",
+    "\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "lightgbm.execute(config=params,\n",
+    "                          docker_registry=DOCKER_REGISTRY,\n",
+    "                          cores_per_worker=2, # Allocating 2 CPU cores per worker instance\n",
+    "                          memory_per_worker=0.5, # Allocating 0.5GB of memory per worker instance\n",
+    "                          stream_log=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Let's look at the trained model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = params['model_output']\n",
+    "model_name = os.path.split(url)[1]\n",
+    "!gsutil cp {url} /tmp/{model_name}\n",
+    "!head /tmp/{model_name}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Runnig a prediction task using the trained model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predict_params = {\n",
+    "    \"task\": \"predict\",\n",
+    "    'metric': 'l2',\n",
+    "    \"data\": \"gs://fairing-lightgbm/regression-example/regression.test\",\n",
+    "    \"input_model\": params['model_output'],\n",
+    "    \"output_result\": \"{}/lightgbm/example/prediction_result_{}.txt\".format(gcs_bucket, model_name)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lightgbm.execute(config=predict_params, docker_registry=DOCKER_REGISTRY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = predict_params['output_result']\n",
+    "file_name = os.path.split(url)[1]\n",
+    "!gsutil cp {url} /tmp/{file_name}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "predictions = pd.read_csv(\"/tmp/{}\".format(file_name), header=None)\n",
+    "print(\"Prediction mean: {}, count: {}\".format(predictions.mean()[0], predictions.count()[0]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/fairing/frameworks/lightgbm_dist_training_init.py
+++ b/fairing/frameworks/lightgbm_dist_training_init.py
@@ -12,4 +12,4 @@ if __name__ == "__main__":
     parser.add_argument('mlist_file', help='LightGBM machine list file')
     args = parser.parse_args()
     utils = importlib.import_module("utils", package=".")
-    utils.init_lightgbm_env(args.config_file, args.mlist_file)
+    print(utils.init_lightgbm_env(args.config_file, args.mlist_file))

--- a/tests/unit/frameworks/test_lightgbm.py
+++ b/tests/unit/frameworks/test_lightgbm.py
@@ -23,7 +23,7 @@ EXMAPLE_CONFIG_FILE_NAME = "/config-file.conf"
 def test_context_files_list():
     with patch('fairing.cloud.storage.GCSStorage.exists'):
         output_map = lightgbm.generate_context_files(
-            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, 1)
     actual = list(output_map.values())
     actual.sort()
     expected = [
@@ -33,13 +33,13 @@ def test_context_files_list():
         posixpath.join(constants.DEFAULT_DEST_PREFIX, 'utils.py')
     ]
     expected.sort()
-    assert actual == expected
+    assert expected == actual
 
 
 def test_context_files_list_dist():
     with patch('fairing.cloud.storage.GCSStorage.exists'):
         output_map = lightgbm.generate_context_files(
-            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, True)
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, 2)
     actual = list(output_map.values())
     actual.sort()
     expected = [
@@ -50,13 +50,13 @@ def test_context_files_list_dist():
         posixpath.join(constants.DEFAULT_DEST_PREFIX, 'utils.py')
     ]
     expected.sort()
-    assert actual == expected
+    assert expected == actual
 
 
 def test_entrypoint_content():
     with patch('fairing.cloud.storage.GCSStorage.exists'):
         output_map = lightgbm.generate_context_files(
-            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, 1)
     entrypoint_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'entrypoint.sh')
     entrypoint_file = None
     for k, v in output_map.items():
@@ -73,12 +73,12 @@ lightgbm config={0}/config.conf
 gsutil cp -r {0}/model.txt gs://lightgbm-test/model.txt
 """.format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
     print(actual)
-    assert actual == expected
+    assert expected == actual
 
 def test_final_config():
     with patch('fairing.cloud.storage.GCSStorage.exists'):
         output_map = lightgbm.generate_context_files(
-            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, 1)
     config_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'config.conf')
     config_file_local = None
     for k, v in output_map.items():
@@ -96,20 +96,20 @@ verbose=1
 model_output={0}/model.txt
 """.format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
     print(actual)
-    assert actual == expected
+    assert expected == actual
 
 def test_input_file_not_found():    
     with pytest.raises(RuntimeError) as excinfo:
         with patch('fairing.cloud.storage.GCSStorage.exists', new=lambda x, y: False):
             _ = lightgbm.generate_context_files(
-                    EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+                    EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, 1)
     err_msg = str(excinfo.value)
     assert "Remote file " in err_msg and "does't exist" in err_msg
 
 def test_entrypoint_content_no_weight_file():
     with patch('fairing.cloud.storage.GCSStorage.exists', new=lambda bucket,path: not path.endswith(".weight")):
         output_map = lightgbm.generate_context_files(
-            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, False)
+            EXAMPLE_CONFIG, EXMAPLE_CONFIG_FILE_NAME, 1)
     entrypoint_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'entrypoint.sh')
     entrypoint_file = None
     for k, v in output_map.items():
@@ -125,4 +125,91 @@ lightgbm config={0}/config.conf
 gsutil cp -r {0}/model.txt gs://lightgbm-test/model.txt
 """.format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
     print(actual)
-    assert actual == expected
+    assert expected == actual
+
+def test_entrypoint_content_dist_data_parallel():
+    config = EXAMPLE_CONFIG.copy()
+    config["tree_learner"] = "data"
+    config["train_data"] = ",".join(["gs://lightgbm-test/regression.train1",
+                            "gs://lightgbm-test/regression.train2"])
+    with patch('fairing.cloud.storage.GCSStorage.exists'):
+        output_map = lightgbm.generate_context_files(
+            config, EXMAPLE_CONFIG_FILE_NAME, 2)
+    entrypoint_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'entrypoint.sh')
+    entrypoint_file = None
+    for k, v in output_map.items():
+        if v == entrypoint_file_in_docker:
+            entrypoint_file = k
+    actual = open(entrypoint_file, "r").read()
+    expected = """#!/bin/sh
+set -e
+RANK=`python lightgbm_dist_training_init.py config.conf mlist.txt`
+case $RANK in
+	0)
+		gsutil cp -r gs://lightgbm-test/regression.train1 /app/train_data
+		gsutil cp -r gs://lightgbm-test/regression.train1.weight /app/train_data.weight
+		;;
+	1)
+		gsutil cp -r gs://lightgbm-test/regression.train2 /app/train_data
+		gsutil cp -r gs://lightgbm-test/regression.train2.weight /app/train_data.weight
+		;;
+esac
+gsutil cp -r gs://lightgbm-test/regression.test {0}/regression.test
+echo 'All files are copied!'
+lightgbm config={0}/config.conf
+gsutil cp -r {0}/model.txt gs://lightgbm-test/model.txt
+""".format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
+    print(actual)
+    assert expected == actual
+
+def test_entrypoint_content_dist_data_parallel_no_weight_files():
+    config = EXAMPLE_CONFIG.copy()
+    config["tree_learner"] = "data"
+    config["train_data"] = ",".join(["gs://lightgbm-test/regression.train1",
+                            "gs://lightgbm-test/regression.train2"])
+    with patch('fairing.cloud.storage.GCSStorage.exists', new=lambda bucket,path: not path.endswith(".weight")):
+        output_map = lightgbm.generate_context_files(
+            config, EXMAPLE_CONFIG_FILE_NAME, 2)
+    entrypoint_file_in_docker = posixpath.join(constants.DEFAULT_DEST_PREFIX, 'entrypoint.sh')
+    entrypoint_file = None
+    for k, v in output_map.items():
+        if v == entrypoint_file_in_docker:
+            entrypoint_file = k
+    actual = open(entrypoint_file, "r").read()
+    expected = """#!/bin/sh
+set -e
+RANK=`python lightgbm_dist_training_init.py config.conf mlist.txt`
+case $RANK in
+	0)
+		gsutil cp -r gs://lightgbm-test/regression.train1 /app/train_data
+		;;
+	1)
+		gsutil cp -r gs://lightgbm-test/regression.train2 /app/train_data
+		;;
+esac
+gsutil cp -r gs://lightgbm-test/regression.test {0}/regression.test
+echo 'All files are copied!'
+lightgbm config={0}/config.conf
+gsutil cp -r {0}/model.txt gs://lightgbm-test/model.txt
+""".format(posixpath.realpath(constants.DEFAULT_DEST_PREFIX))
+    print(actual)
+    assert expected == actual
+
+
+def test_dist_training_misconfigured_input_files():
+    config = EXAMPLE_CONFIG.copy()
+    config["tree_learner"] = "feature"
+    config["train_data"] = ",".join(["gs://lightgbm-test/regression.train1",
+                            "gs://lightgbm-test/regression.train2"])
+    with pytest.raises(RuntimeError) as excinfo:
+        lightgbm.generate_context_files(config, EXMAPLE_CONFIG_FILE_NAME, 2)
+    assert "train_data has more than one file specified" in str(excinfo.value)
+
+def test_dist_training_misconfigured_num_machines():
+    config = EXAMPLE_CONFIG.copy()
+    config["tree_learner"] = "data"
+    config["train_data"] = ",".join(["gs://lightgbm-test/regression.train1",
+                            "gs://lightgbm-test/regression.train2"])
+    with pytest.raises(RuntimeError) as excinfo:
+        lightgbm.generate_context_files(config, EXMAPLE_CONFIG_FILE_NAME, 3)
+    assert "field in the config should be equal to the num_machines=3 config value." in str(excinfo.value)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds support for data parallel mode in LightGBM. The user can specify list of training input files that should be distributed across the workers in a distributed training mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #274 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for data parallel mode in LightGBM
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/276)
<!-- Reviewable:end -->
