### PR TITLE
remove useless set_model

### DIFF
--- a/examples/kubeflow/main.py
+++ b/examples/kubeflow/main.py
@@ -76,5 +76,4 @@ class TensorflowModel():
 
 if __name__ == '__main__':
     fairing.config.set_builder(name='cluster')
-    fairing.config.set_model(TensorflowModel())
     fairing.config.run()

--- a/examples/kubernetes-in-cluster-builder/main.py
+++ b/examples/kubernetes-in-cluster-builder/main.py
@@ -75,5 +75,4 @@ class MyModel(object):
 
 
 if __name__ == '__main__':
-    fairing.config.set_model(MyModel())
     fairing.config.run()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `set_model` function has been removed in PR #114 , but the main.py files are not updated. Seems only need to call fairing.run, no need set_model. The PR is to remove the set_model calling from main.py. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/278)
<!-- Reviewable:end -->
