### PR TITLE
Add ability to specify context_source for k8s backends

### DIFF
--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -46,9 +46,9 @@ class BackendInterface(object):
 
 class KubernetesBackend(BackendInterface):
 
-    def __init__(self, namespace=None, context_source=None):
+    def __init__(self, namespace=None, build_context_source=None):
         self._namespace = namespace
-        self._context_source = context_source
+        self._build_context_source = build_context_source
     
     def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
         if not needs_deps_installation:
@@ -61,7 +61,7 @@ class KubernetesBackend(BackendInterface):
                                   registry=registry,
                                   pod_spec_mutators=pod_spec_mutators,
                                   namespace=self._namespace,
-                                  context_source=self._context_source)
+                                  context_source=self._build_context_source)
         elif ml_tasks_utils.is_docker_daemon_exists():
             return DockerBuilder(preprocessor=preprocessor,
                                  base_image=base_image,
@@ -78,9 +78,9 @@ class KubernetesBackend(BackendInterface):
 
 class GKEBackend(KubernetesBackend):
 
-    def __init__(self, namespace=None, context_source=None):
-        context_source = context_source or gcs_context.GCSContextSource(namespace=namespace)
-        super(GKEBackend, self).__init__(namespace, context_source)
+    def __init__(self, namespace=None, build_context_source=None):
+        build_context_source = build_context_source or gcs_context.GCSContextSource(namespace=namespace)
+        super(GKEBackend, self).__init__(namespace, build_context_source)
     
     def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
         pod_spec_mutators = pod_spec_mutators or []
@@ -129,13 +129,13 @@ class GKEBackend(KubernetesBackend):
 
 class KubeflowBackend(KubernetesBackend):
 
-    def __init__(self, namespace="kubeflow", context_source=None):
-        super(KubeflowBackend, self).__init__(namespace, context_source)
+    def __init__(self, namespace="kubeflow", build_context_source=None):
+        super(KubeflowBackend, self).__init__(namespace, build_context_source)
 
 class KubeflowGKEBackend(GKEBackend):
 
-    def __init__(self, namespace="kubeflow", context_source=None):
-        super(KubeflowGKEBackend, self).__init__(namespace, context_source)
+    def __init__(self, namespace="kubeflow", build_context_source=None):
+        super(KubeflowGKEBackend, self).__init__(namespace, build_context_source)
 
 class GCPManagedBackend(BackendInterface):
 

--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -4,6 +4,7 @@ import sys
 
 import fairing
 from fairing.builders.docker.docker import DockerBuilder
+from fairing.builders.cluster import gcs_context
 from fairing.builders.cluster.cluster import ClusterBuilder
 from fairing.builders.append.append import AppendBuilder
 from fairing.deployers.gcp.gcp import GCPJob
@@ -78,6 +79,7 @@ class KubernetesBackend(BackendInterface):
 class GKEBackend(KubernetesBackend):
 
     def __init__(self, namespace=None, context_source=None):
+        context_source = context_source or gcs_context.GCSContextSource(namespace=namespace)
         super(GKEBackend, self).__init__(namespace, context_source)
     
     def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
@@ -156,7 +158,8 @@ class GCPManagedBackend(BackendInterface):
             return ClusterBuilder(preprocessor=preprocessor,
                                   base_image=base_image,
                                   registry=registry,
-                                  pod_spec_mutators=pod_spec_mutators)
+                                  pod_spec_mutators=pod_spec_mutators,
+                                  context_source=gcs_context.GCSContextSource(namespace="kubeflow"))
         elif ml_tasks_utils.is_docker_daemon_exists():
             return DockerBuilder(preprocessor=preprocessor,
                                  base_image=base_image,

--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -45,8 +45,9 @@ class BackendInterface(object):
 
 class KubernetesBackend(BackendInterface):
 
-    def __init__(self, namespace=None):
+    def __init__(self, namespace=None, context_source=None):
         self._namespace = namespace
+        self._context_source = context_source
     
     def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
         if not needs_deps_installation:
@@ -58,7 +59,8 @@ class KubernetesBackend(BackendInterface):
                                   base_image=base_image,
                                   registry=registry,
                                   pod_spec_mutators=pod_spec_mutators,
-                                  namespace=self._namespace)
+                                  namespace=self._namespace,
+                                  context_source=self._context_source)
         elif ml_tasks_utils.is_docker_daemon_exists():
             return DockerBuilder(preprocessor=preprocessor,
                                  base_image=base_image,
@@ -75,8 +77,8 @@ class KubernetesBackend(BackendInterface):
 
 class GKEBackend(KubernetesBackend):
 
-    def __init__(self, namespace=None):
-        super(GKEBackend, self).__init__(namespace)
+    def __init__(self, namespace=None, context_source=None):
+        super(GKEBackend, self).__init__(namespace, context_source)
     
     def get_builder(self, preprocessor, base_image, registry, needs_deps_installation=True, pod_spec_mutators=None):
         pod_spec_mutators = pod_spec_mutators or []
@@ -125,13 +127,13 @@ class GKEBackend(KubernetesBackend):
 
 class KubeflowBackend(KubernetesBackend):
 
-    def __init__(self, namespace="kubeflow"):
-        super(KubeflowBackend, self).__init__(namespace)
+    def __init__(self, namespace="kubeflow", context_source=None):
+        super(KubeflowBackend, self).__init__(namespace, context_source)
 
 class KubeflowGKEBackend(GKEBackend):
 
-    def __init__(self, namespace="kubeflow"):
-        super(KubeflowGKEBackend, self).__init__(namespace)
+    def __init__(self, namespace="kubeflow", context_source=None):
+        super(KubeflowGKEBackend, self).__init__(namespace, context_source)
 
 class GCPManagedBackend(BackendInterface):
 

--- a/fairing/builders/cluster/cluster.py
+++ b/fairing/builders/cluster/cluster.py
@@ -45,7 +45,7 @@ class ClusterBuilder(BaseBuilder):
             )
         self.manager = KubeManager()
         if context_source is None:
-            context_source = gcs_context.GCSContextSource(namespace=namespace)
+            raise RuntimeError("context_source is not specified")
         self.context_source = context_source
         self.pod_spec_mutators = pod_spec_mutators or []
         self.namespace = namespace

--- a/tests/integration/common/test_kubeflow_training.py
+++ b/tests/integration/common/test_kubeflow_training.py
@@ -11,6 +11,7 @@ from google.cloud import storage
 from fairing import TrainJob
 from fairing.backends import KubernetesBackend, KubeflowBackend
 from fairing.backends import KubeflowGKEBackend, GKEBackend, GCPManagedBackend
+from fairing.builders.cluster import gcs_context
 
 GCS_PROJECT_ID = fairing.cloud.gcp.guess_project_name()
 DOCKER_REGISTRY = 'gcr.io/{}'.format(GCS_PROJECT_ID)
@@ -31,7 +32,8 @@ def run_submission_with_function_preprocessor(capsys, deployer="job", builder="a
     base_image = 'registry.hub.docker.com/library/python:{}'.format(py_version)
     if builder=='cluster':
         fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY,
-                                   pod_spec_mutators=[fairing.cloud.gcp.add_gcp_credentials])
+                                   pod_spec_mutators=[fairing.cloud.gcp.add_gcp_credentials],
+                                   context_source=gcs_context.GCSContextSource(namespace=namespace))
     else:
         fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY)
     fairing.config.set_deployer(deployer, namespace=namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding ability to specify context_source for kubernetes-related backends.
Kaniko supports not only GCS context, but S3 and GitHub.
For future implementation, we need the ability to change that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related #282 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/281)
<!-- Reviewable:end -->
