### PR TITLE
update examples to add set_preprocessor

### DIFF
--- a/examples/distributed-training/main.py
+++ b/examples/distributed-training/main.py
@@ -31,8 +31,6 @@ import logging
 import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
 
-import fairing
-
 
 MAX_STEPS = 1000
 LEARNING_RATE = 0.001
@@ -230,6 +228,12 @@ class TensorflowModel(object):
 
 
 if __name__ == '__main__':
-    fairing.config.set_builder(name='docker', registry='gcr.io/mrick-gcp', base_image='tensorflow/tensorflow')
-    fairing.config.set_deployer(name='tfjob', namespace='default', worker_count=1, ps_count=1)
-    fairing.config.run()
+    if os.getenv('FAIRING_RUNTIME', None) is None:
+        import fairing
+        fairing.config.set_preprocessor('python', input_files=[__file__])
+        fairing.config.set_builder(name='docker', registry='gcr.io/mrick-gcp', base_image='tensorflow/tensorflow')
+        fairing.config.set_deployer(name='tfjob', namespace='default', worker_count=1, ps_count=1)
+        fairing.config.run()
+    else:
+        remote_train = TensorflowModel()
+        remote_train.train()

--- a/examples/gcp/hello-world-gpu-pytorch.py
+++ b/examples/gcp/hello-world-gpu-pytorch.py
@@ -1,5 +1,4 @@
 import os
-import fairing
 import time
 import multiprocessing
 
@@ -18,6 +17,7 @@ if __name__ == '__main__':
     if os.getenv('FAIRING_RUNTIME', None) is not None:
         train()
     else:
+        import fairing
         # Setting up google container repositories (GCR) for storing output containers
         # You can use any docker container registry istead of GCR
         GCP_PROJECT = fairing.cloud.gcp.guess_project_name()

--- a/examples/kubeflow-gke/main.py
+++ b/examples/kubeflow-gke/main.py
@@ -21,10 +21,6 @@ import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
 from tensorflow.examples.tutorials.mnist import mnist
 
-import fairing
-
-fairing.config.set_builder('append', base_image='tensorflow/tensorflow:1.13.1-py3')
-fairing.config.run()
 
 INPUT_DATA_DIR = '/tmp/tensorflow/mnist/input_data/'
 MAX_STEPS = 2000
@@ -37,7 +33,6 @@ HIDDEN_2 = 32
 # we are instead appending HOSTNAME to the logdir
 LOG_DIR = os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
                        'tensorflow/mnist/logs/fully_connected_feed/', os.getenv('HOSTNAME', ''))
-MODEL_DIR = os.path.join(LOG_DIR, 'model.ckpt')
 
 
 def train():
@@ -77,4 +72,10 @@ def train():
 
 
 if __name__ == '__main__':
-    train()
+    if os.getenv('FAIRING_RUNTIME', None) is None:
+        import fairing
+        fairing.config.set_preprocessor('python', input_files=[__file__])
+        fairing.config.set_builder('append', base_image='tensorflow/tensorflow:1.13.1-py3')
+        fairing.config.run()
+    else:
+        train()

--- a/examples/kubeflow/main.py
+++ b/examples/kubeflow/main.py
@@ -21,7 +21,6 @@ import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
 from tensorflow.examples.tutorials.mnist import mnist
 
-import fairing
 
 INPUT_DATA_DIR = '/tmp/tensorflow/mnist/input_data/'
 MAX_STEPS = 2000
@@ -34,8 +33,6 @@ HIDDEN_2 = 32
 # we are instead appending HOSTNAME to the logdir
 LOG_DIR = os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
                        'tensorflow/mnist/logs/fully_connected_feed/', os.getenv('HOSTNAME', ''))
-MODEL_DIR = os.path.join(LOG_DIR, 'model.ckpt')
-
 
 class TensorflowModel():
     def train(self, **kwargs):
@@ -75,5 +72,12 @@ class TensorflowModel():
 
 
 if __name__ == '__main__':
-    fairing.config.set_builder(name='cluster')
-    fairing.config.run()
+    if os.getenv('FAIRING_RUNTIME', None) is None:
+        import fairing
+        fairing.config.set_preprocessor('python', input_files=[__file__])
+        fairing.config.set_builder(name='docker', registry='<your-registry-name>',
+                                   base_image='tensorflow/tensorflow:1.13.1-py3')
+        fairing.config.run()
+    else:
+        remote_train = TensorflowModel()
+        remote_train.train()

--- a/examples/kubernetes-in-cluster-builder/main.py
+++ b/examples/kubernetes-in-cluster-builder/main.py
@@ -21,8 +21,6 @@ import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
 from tensorflow.examples.tutorials.mnist import mnist
 
-import fairing
-fairing.config.set_builder(name='cluster', registry='<your-registry-here>')
 
 INPUT_DATA_DIR = '/tmp/tensorflow/mnist/input_data/'
 MAX_STEPS = 2000
@@ -35,7 +33,6 @@ HIDDEN_2 = 32
 # we are instead appending HOSTNAME to the logdir
 LOG_DIR = os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
                        'tensorflow/mnist/logs/fully_connected_feed/', os.getenv('HOSTNAME', ''))
-MODEL_DIR = os.path.join(LOG_DIR, 'model.ckpt')
 
 
 class MyModel(object):
@@ -75,4 +72,10 @@ class MyModel(object):
 
 
 if __name__ == '__main__':
-    fairing.config.run()
+    if os.getenv('FAIRING_RUNTIME', None) is None:
+        import fairing
+        fairing.config.set_preprocessor('python', input_files=[__file__])
+        fairing.config.set_builder(name='cluster', registry='<your-registry-here>')
+        fairing.config.run()
+    else:
+        train()

--- a/examples/kubernetes/main.py
+++ b/examples/kubernetes/main.py
@@ -22,11 +22,6 @@ from tensorflow.examples.tutorials.mnist import input_data
 from tensorflow.examples.tutorials.mnist import mnist
 
 
-import fairing
-fairing.config.set_builder('docker', registry='<your-registry-name>',
-                           base_image='tensorflow/tensorflow:1.13.1-py3')
-fairing.config.run()
-
 INPUT_DATA_DIR = '/tmp/tensorflow/mnist/input_data/'
 MAX_STEPS = 2000
 BATCH_SIZE = 100
@@ -38,7 +33,6 @@ HIDDEN_2 = 32
 # we are instead appending HOSTNAME to the logdir
 LOG_DIR = os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
                        'tensorflow/mnist/logs/fully_connected_feed/', os.getenv('HOSTNAME', ''))
-MODEL_DIR = os.path.join(LOG_DIR, 'model.ckpt')
 
 
 def train():
@@ -77,4 +71,11 @@ def train():
 
 
 if __name__ == '__main__':
-    train()
+    if os.getenv('FAIRING_RUNTIME', None) is None:
+        import fairing
+        fairing.config.set_preprocessor('python', input_files=[__file__])
+        fairing.config.set_builder('docker', registry='<your-registry-name>',
+                               base_image='tensorflow/tensorflow:1.13.1-py3')
+        fairing.config.run()
+    else:
+        train()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When I warming up the Kubeflow Fairing, and try some examples for on-prem cluster, I found the defined function/class is not built in the image, so while create pod from the image, the training is not run (some of training function run locally). That's not right. Checked details, I found the need to `set_preprocessor` and point the `function_obj` in the `set_preprocessor`. The RP is to update the example to enhance this. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/285)
<!-- Reviewable:end -->
