### PR TITLE
Warn users who are using function preprocessor and not in notebook

### DIFF
--- a/fairing/preprocessors/function.py
+++ b/fairing/preprocessors/function.py
@@ -1,6 +1,7 @@
 import cloudpickle
 import fairing
 import glob
+import logging
 import os
 import sys
 import types
@@ -11,6 +12,9 @@ from enum import Enum
 from fairing.constants import constants
 from .base import BasePreProcessor
 from fairing.functions.function_shim import get_execution_obj_type, ObjectType
+from fairing.notebook import notebook_util
+
+logger = logging.getLogger(__name__)
 
 FUNCTION_SHIM = 'function_shim.py'
 SERIALIZED_FN_FILE = 'pickled_fn.p'
@@ -36,6 +40,11 @@ class FunctionPreProcessor(BasePreProcessor):
             output_map=output_map,
             path_prefix=path_prefix,
             input_files=input_files)
+
+        if not notebook_util.is_in_notebook():
+            logger.warning("The FunctionPreProcessor is optimized for using in a notebook or IPython environment. "
+                           "For it to work, the python version should be same for both local python and the python in "
+                           "the docker. Please look at alternatives like BasePreprocessor or FullNotebookPreprocessor.")
 
         if get_execution_obj_type(function_obj) ==  ObjectType.NOT_SUPPORTED:
             raise RuntimeError("Object must of type function or a class")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adding a warning if user is using the function preprocessor in non-netebook environment, as below:

```
The FunctionPreProcessor is optimized for using in a notebook or IPython environment. For it to work, the python version should be same for both local python and the python in  the docker. Please look at alternatives like BasePreprocessor or FullNotebookPreprocessor.
```

**Which issue(s) this PR fixes**:
Fixes #289

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/292)
<!-- Reviewable:end -->
