### PR TITLE
allow user input service type

### DIFF
--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -75,8 +75,8 @@ class KubernetesBackend(BackendInterface):
     def get_training_deployer(self, pod_spec_mutators = None):
         return Job(self._namespace, pod_spec_mutators=pod_spec_mutators)
     
-    def get_serving_deployer(self, model_class):
-        return Serving(model_class, namespace=self._namespace)
+    def get_serving_deployer(self, model_class, service_type='LoadBalancer'):
+        return Serving(model_class, namespace=self._namespace, service_type=service_type)
 
 class GKEBackend(KubernetesBackend):
 
@@ -123,8 +123,8 @@ class GKEBackend(KubernetesBackend):
         pod_spec_mutators.append(gcp.add_gcp_credentials_if_exists)
         return Job(namespace=self._namespace, pod_spec_mutators=pod_spec_mutators)
     
-    def get_serving_deployer(self, model_class):
-        return Serving(model_class, namespace=self._namespace)
+    def get_serving_deployer(self, model_class, service_type='LoadBalancer'):
+        return Serving(model_class, namespace=self._namespace, service_type=service_type)
 
     def get_docker_registry(self):
         return fairing.cloud.gcp.get_default_docker_registry()

--- a/fairing/ml_tasks/tasks.py
+++ b/fairing/ml_tasks/tasks.py
@@ -79,14 +79,16 @@ class TrainJob(BaseTask):
 
 class PredictionEndpoint(BaseTask):
 
-    def __init__(self, model_class, base_docker_image=None, docker_registry=None, input_files=None, backend=None):
+    def __init__(self, model_class, base_docker_image=None, docker_registry=None, input_files=None, backend=None,
+                 service_type='LoadBalancer'):
         self.model_class = model_class
+        self.service_type = service_type
         super().__init__(model_class, base_docker_image, docker_registry, input_files, backend=backend)
 
     def create(self):
         self._build()
         logging.info("Deploying the endpoint.")
-        self._deployer = self._backend.get_serving_deployer(self.model_class.__name__)
+        self._deployer = self._backend.get_serving_deployer(self.model_class.__name__, service_type=self.service_type)
         self.url = self._deployer.deploy(self.pod_spec)
         logger.warning("Prediction endpoint: {}".format(self.url))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Should allow user input service type, instead of hard code to `LoadBalancer`.  I know that's needed by notebook, but some uses may want to predict in the cluster, especially for on-prem cases. See more in #293 .
The `service_type` has been defined in the [fairing/deployers/serving/serving.py](https://github.com/kubeflow/fairing/blob/master/fairing/deployers/serving/serving.py#L26), but not expose to user defination functions. The PR is to expose the `service_type` so that user can configuration.

Note that the PR only updates some backends functions  `get_serving_deployer` which has been implemented.

**Which issue(s) this PR fixes** :
Fixes #293

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/294)
<!-- Reviewable:end -->
