### PR TITLE
support kfserving in fairing

### DIFF
--- a/examples/kfserving/main.py
+++ b/examples/kfserving/main.py
@@ -1,0 +1,21 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import fairing
+
+if __name__ == '__main__':
+        fairing.config.set_deployer('kfserving', namespace='kubeflow', framework='tensorflow',
+                                   default_model_uri='gs://kfserving-samples/models/tensorflow/flowers',cleanup=True)
+        fairing.config.run()

--- a/fairing/config.py
+++ b/fairing/config.py
@@ -13,6 +13,7 @@ from fairing.deployers.serving.serving import Serving
 from fairing.deployers.tfjob.tfjob import TfJob
 from fairing.deployers.gcp.gcp import GCPJob
 from fairing.deployers.deployer import DeployerInterface
+from fairing.deployers.kfserving.kfserving import KFServing
 
 from fairing.notebook import notebook_util
 
@@ -41,6 +42,7 @@ deployer_map = {
     'tfjob': TfJob,
     'gcp': GCPJob,
     'serving': Serving,
+    'kfserving': KFServing,
 }
 
 

--- a/fairing/constants/constants.py
+++ b/fairing/constants/constants.py
@@ -21,3 +21,13 @@ TF_JOB_PLURAL = "tfjobs"
 TF_JOB_VERSION = "v1beta2"
 TF_JOB_DEFAULT_NAME = 'fairing-tfjob-'
 TF_JOB_DEPLOYER_TYPE = 'tfjob'
+
+# KFServing constants
+KFSERVING_GROUP = "serving.kubeflow.org"
+KFSERVING_KIND = "KFService"
+KFSERVING_PLURAL = "kfservices"
+KFSERVING_VERSION = "v1alpha1"
+KFSERVING_DEFAULT_NAME = 'fairing-kfserving-'
+KFSERVING_DEPLOYER_TYPE = 'kfservice'
+KFSERVING_CONTAINER_NAME = 'user-container'
+

--- a/fairing/deployers/kfserving/kfserving.py
+++ b/fairing/deployers/kfserving/kfserving.py
@@ -1,0 +1,122 @@
+import json
+import uuid
+import logging
+
+from fairing.constants import constants
+from fairing.deployers.job.job import Job
+from fairing.deployers.deployer import DeployerInterface
+from kubernetes import client as k8s_client
+from kubernetes.client.rest import ApiException
+from fairing.kubernetes.manager import KubeManager
+from fairing import utils
+
+logger = logging.getLogger(__name__)
+
+class KFServing(DeployerInterface):
+    """
+    Serves a prediction endpoint using Kubeflow KFServing.
+    Attributes:
+        framework: The framework for the kfservice, such as Tensorflow, XGBoost and ScikitLearn etc.
+        default_model_uri: URI pointing to Saved Model assets for default service.
+        canary_model_uri: URI pointing to Saved Model assets for canary service.
+        canary_traffic_percent: The amount of traffic to sent to the canary, defaults to 0.
+        namespace: The k8s namespace where the kfservice will be deployed.
+        labels: Labels for the kfservice, separate with commas if have more than one.
+        annotations: Annotations for the kfservice, separate with commas if have more than one.
+        custom_default_spec: A flexible custom default specification for arbitrary customer provided containers.
+        custom_canary_spec: A flexible custom canary specification for arbitrary customer provided containers.
+        stream_log: Show log or not when kfservice started, defaults to True.
+        cleanup: Delete the kfserving or not, defaults to False.
+    """
+
+    def __init__(self, framework, default_model_uri=None, canary_model_uri=None, canary_traffic_percent=0,
+                 namespace=None, labels=None, annotations=None, custom_default_spec=None, 
+                 custom_canary_spec=None, stream_log=True, cleanup=False):
+        self.framework = framework
+        self.default_model_uri = default_model_uri
+        self.canary_model_uri = canary_model_uri
+        self.canary_traffic_percent = canary_traffic_percent
+        self.annotations = annotations
+        self.set_labels(labels)
+        self.cleanup = cleanup
+        self.custom_default_spec = custom_default_spec
+        self.custom_canary_spec = custom_canary_spec
+        self.stream_log = stream_log
+        self.backend = KubeManager()
+
+        if namespace is None:
+            self.namespace = utils.get_default_target_namespace()
+        else:
+            self.namespace = namespace
+
+    def set_labels(self, labels):
+        self.fairing_id = str(uuid.uuid1())
+        self.labels = {'fairing-id': self.fairing_id}
+        if labels:
+            self.labels.update(labels)
+
+    def deploy(self, template_spec):
+        self.kfservice = self.generate_kfservice()
+        self.created_kfserving = self.backend.create_kfserving(self.namespace, self.kfservice)
+        if self.stream_log:
+            self.get_logs()
+
+        kfservice_name = self.created_kfserving['metadata']['name']
+        logger.warn("Deployed the kfservice {} successfully.".format(kfservice_name))
+
+        if self.cleanup:
+            logger.warn("Cleaning up kfservice {}...".format(kfservice_name))
+            self.backend.delete_kfserving(kfservice_name, self.namespace)
+
+        return kfservice_name
+
+    def generate_kfservice(self):
+
+        spec = {}
+        spec['default'] = {}
+        if self.framework != 'custom':
+            if self.default_model_uri != None:
+                spec['default'][self.framework] = {}
+                spec['default'][self.framework]['modelUri'] = self.default_model_uri
+            else:
+                raise RuntimeError("The default_model_uri must be defined if the framework is not custom.")
+        else:
+            if self.custom_default_spec != None:
+                # TBD @jinchi Need to validate the custom_default_spec before executing.
+                spec['default'][self.framework] = self.custom_default_spec                
+            else:
+                raise RuntimeError("The custom_default_spec must be defined if the framework is custom.")
+
+        if self.framework != 'custom':
+            if self.canary_model_uri != None:
+                spec['canary'] = {}
+                spec['canary'][self.framework] = {}
+                spec['canary'][self.framework]['modelUri'] = self.canary_model_uri
+                spec['canaryTrafficPercent'] = self.canary_traffic_percent
+        else:
+            if self.custom_default_spec != None:
+                spec['canary'] = {}
+                spec['canary'][self.framework] = self.custom_canary_spec
+                spec['canaryTrafficPercent'] = self.canary_traffic_percent
+
+        metadata=k8s_client.V1ObjectMeta(
+                generate_name = constants.KFSERVING_DEFAULT_NAME,
+                namespace = self.namespace,
+                labels = self.labels,
+                annotations = self.annotations
+            )
+
+        kfservice = {}
+        kfservice['kind'] = constants.KFSERVING_KIND
+        kfservice['apiVersion'] = constants.KFSERVING_GROUP + '/' + constants.KFSERVING_VERSION
+        kfservice['metadata'] = metadata
+        kfservice['spec'] = spec
+
+        return kfservice
+
+    def get_logs(self):
+        name = self.created_kfserving['metadata']['name']
+        namespace = self.created_kfserving['metadata']['namespace']
+
+        self.backend.log(name, namespace, self.labels, 
+                         container=constants.KFSERVING_CONTAINER_NAME, follow=False)

--- a/tests/unit/deployers/kfserving.py
+++ b/tests/unit/deployers/kfserving.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+from fairing.deployers.kfserving.kfserving import KFServing
+from fairing.constants import constants
+
+DEFAULT_URI = 'gs://kfserving-samples/models/tensorflow/flowers'
+CANARY_URI = 'gs://kfserving-samples/models/tensorflow/flowers'
+
+def run_unit_test_kfserving(framework, default_model_uri, **kwargs):
+    kfsvc_name = 'test_kfservice'
+
+    with patch('fairing.deployers.kfserving.kfserving.KFServing.deploy', return_value=kfsvc_name):
+        kfsvc = KFServing(framework=framework, default_model_uri=default_model_uri, **kwargs)
+        generated_kfsvc = str(kfsvc.generate_kfservice())
+        assert constants.KFSERVING_KIND in generated_kfsvc
+        assert constants.KFSERVING_GROUP + '/' + constants.KFSERVING_VERSION in generated_kfsvc
+        for key in kwargs:
+            if key != "labels":
+                assert str(kwargs[key]) in generated_kfsvc
+            else:
+                assert "test_labels" in generated_kfsvc
+        assert kfsvc_name == kfsvc.deploy("test")
+
+# Test kfserving function with default_model_uri.
+def test_kfserving_default_model_spec():
+    run_unit_test_kfserving('tensorflow', DEFAULT_URI)
+
+# Test kfserving function with namespace, default_model_uri and canary_model_uri.
+def test_kfserving_default_canary_model_spec():
+    run_unit_test_kfserving('tensorflow', DEFAULT_URI, 
+                            namespace='kubeflow',
+                            canary_model_uri=CANARY_URI)
+
+# Test kfserving function with namespace, default_model_uri, canary_model_uri,
+# and canary_traffic_percent
+def test_kfserving_canary_traffic_percent():
+    run_unit_test_kfserving('tensorflow', DEFAULT_URI, 
+                            namespace='kubeflow', 
+                            canary_model_uri=CANARY_URI,
+                            canary_traffic_percent=10)
+
+# Test kfserving function with some labels and annotations
+def test_kfserving_labels_annotations():
+    run_unit_test_kfserving('tensorflow', DEFAULT_URI, 
+                            namespace='kubeflow', 
+                            labels={'test-id': 'test_labels'},
+                            annotations="test=test123")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Support KFServing in Fairing.

**Which issue(s) this PR fixes** :
Fixes #290 

**Special notes for your reviewer**:

1. The intergration tests for the kfserving are not added, since the automation platform should not have the kfserving installation. But I tested most of cases in the on-prem cluster, and we can add later once the kfserving is installed for test platform.

2. I updated the `log()` function in the `fairing/kubernetes/manager.py` to satify the implements, since there are two container in the pod, we need to point out which container logs will be got.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KFServing to deploy model service
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/299)
<!-- Reviewable:end -->
