### PR TITLE
Better error message when tf-job version mismatch

### DIFF
--- a/fairing/kubernetes/manager.py
+++ b/fairing/kubernetes/manager.py
@@ -24,13 +24,17 @@ class KubeManager(object):
     def create_tf_job(self, namespace, job):
         """Create the provided TFJob in the specified namespace"""
         api_instance = client.CustomObjectsApi()
-        return api_instance.create_namespaced_custom_object(
-            constants.TF_JOB_GROUP,
-            constants.TF_JOB_VERSION,
-            namespace,
-            constants.TF_JOB_PLURAL,
-            job
-        )
+        try:
+            return api_instance.create_namespaced_custom_object(
+                constants.TF_JOB_GROUP,
+                constants.TF_JOB_VERSION,
+                namespace,
+                constants.TF_JOB_PLURAL,
+                job
+            )
+        except client.rest.ApiException:
+            raise RuntimeError("Failed to create TFJob. Perhaps the CRD TFJob version "
+                               "{} in not installed?".format(constants.TF_JOB_VERSION))
 
     def create_deployment(self, namespace, deployment):
         """Create an V1Deployment in the specified namespace"""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When a user runs an older tf-job operator. The error message thrown by fairing is a standard HTTP 404 message, see in #296. We should give better instructions for the user to resolve this situation.

**Which issue(s) this PR fixes**:
Fixes #277 

**Special notes for your reviewer**:

The quick way is try to catch the ApiException, and then print some useful message for user, such as below:
```
Failed to create TFJob. Checked the cluster to ensure the TFJob version v1beta2 installed.
Traceback (most recent call last):
  File "main.py", line 236, in <module>
    fairing.config.run()
  File "/opt/kubeflow/python3/python36/lib/python3.6/site-packages/fairing/config.py", line 106, in run
    deployer.deploy(pod_spec)
  File "/opt/kubeflow/python3/python36/lib/python3.6/site-packages/fairing/deployers/job/job.py", line 64, in deploy
    name = self.create_resource()
  File "/opt/kubeflow/python3/python36/lib/python3.6/site-packages/fairing/deployers/tfjob/tfjob.py", line 29, in create_resource
    raise RuntimeError("Error getting for TFJOB creation.")
RuntimeError: Error getting for TFJOB creation.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/305)
<!-- Reviewable:end -->
