### PR TITLE
Add a option to let user cleanup tfjob

### DIFF
--- a/fairing/deployers/tfjob/tfjob.py
+++ b/fairing/deployers/tfjob/tfjob.py
@@ -1,15 +1,18 @@
+import logging
 from kubernetes import client as k8s_client
 
 from fairing.constants import constants
 from fairing.deployers.job.job import Job
 
+logger = logging.getLogger(__name__)
+
 class TfJob(Job):
     def __init__(self, namespace=None, worker_count=1, ps_count=0,
                  chief_count=1, runs=1, job_name=constants.TF_JOB_DEFAULT_NAME, stream_log=True, labels=None,
-                 pod_spec_mutators=None):
+                 pod_spec_mutators=None, cleanup=False):
         super(TfJob, self).__init__(namespace, runs, job_name=job_name, stream_log=stream_log,
                                     deployer_type=constants.TF_JOB_DEPLOYER_TYPE, labels=labels,
-                                    pod_spec_mutators=pod_spec_mutators)
+                                    pod_spec_mutators=pod_spec_mutators, cleanup=cleanup)
         self.distribution = {
             'Worker': worker_count,
             'PS': ps_count,
@@ -47,7 +50,8 @@ class TfJob(Job):
         tf_job = {}
         tf_job['kind'] = constants.TF_JOB_KIND
         tf_job['apiVersion'] = 'kubeflow.org/' + constants.TF_JOB_VERSION
-        tf_job['metadata'] = k8s_client.V1ObjectMeta(generate_name=self.job_name)
+        tf_job['metadata'] = k8s_client.V1ObjectMeta(generate_name=self.job_name,
+                                                     labels=self.labels)
         tf_job['spec'] = spec
 
         return tf_job
@@ -67,3 +71,7 @@ class TfJob(Job):
             'tf-job-name': name
         }
         self.backend.log(name, namespace, labels, container="tensorflow")
+
+        if self.cleanup:
+            logger.warn("Cleaning up TFJob {}...".format(name))
+            self.backend.delete_tf_job(name, self.namespace)

--- a/fairing/kubernetes/manager.py
+++ b/fairing/kubernetes/manager.py
@@ -36,6 +36,17 @@ class KubeManager(object):
             raise RuntimeError("Failed to create TFJob. Perhaps the CRD TFJob version "
                                "{} in not installed?".format(constants.TF_JOB_VERSION))
 
+    def delete_tf_job(self, name, namespace):
+        """Delete the provided TFJob in the specified namespace"""
+        api_instance = client.CustomObjectsApi()
+        return api_instance.delete_namespaced_custom_object(
+            constants.TF_JOB_GROUP,
+            constants.TF_JOB_VERSION,
+            namespace,
+            constants.TF_JOB_PLURAL,
+            name,
+            client.V1DeleteOptions())
+
     def create_deployment(self, namespace, deployment):
         """Create an V1Deployment in the specified namespace"""
         api_instance = client.AppsV1Api()

--- a/tests/integration/common/test_kubeflow_training.py
+++ b/tests/integration/common/test_kubeflow_training.py
@@ -8,10 +8,13 @@ import time
 import uuid
 
 from google.cloud import storage
+from kubernetes import client
+
 from fairing import TrainJob
 from fairing.backends import KubernetesBackend, KubeflowBackend
 from fairing.backends import KubeflowGKEBackend, GKEBackend, GCPManagedBackend
 from fairing.builders.cluster import gcs_context
+from fairing.constants import constants
 
 GCS_PROJECT_ID = fairing.cloud.gcp.guess_project_name()
 DOCKER_REGISTRY = 'gcr.io/{}'.format(GCS_PROJECT_ID)
@@ -27,7 +30,16 @@ def train_fn(msg):
 # other modules.
 train_fn.__module__ = '__main__'
 
-def run_submission_with_function_preprocessor(capsys, deployer="job", builder="append", namespace="default"):
+def get_tfjobs_with_labels(labels):
+        api_instance = client.CustomObjectsApi()
+        return api_instance.list_cluster_custom_object(
+                constants.TF_JOB_GROUP,
+                constants.TF_JOB_VERSION,
+                constants.TF_JOB_PLURAL,
+                label_selector=labels)
+
+def run_submission_with_function_preprocessor(capsys, deployer="job", builder="append",
+                                              namespace="default", cleanup=False):
     py_version = ".".join([str(x) for x in sys.version_info[0:3]])
     base_image = 'registry.hub.docker.com/library/python:{}'.format(py_version)
     if builder=='cluster':
@@ -36,19 +48,33 @@ def run_submission_with_function_preprocessor(capsys, deployer="job", builder="a
                                    context_source=gcs_context.GCSContextSource(namespace=namespace))
     else:
         fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY)
-    fairing.config.set_deployer(deployer, namespace=namespace)
 
     expected_result = str(uuid.uuid4())
+    fairing.config.set_deployer(deployer, namespace=namespace, cleanup=cleanup,
+                                labels={'pytest-id': expected_result})
+
     remote_train = fairing.config.fn(lambda : train_fn(expected_result))
     remote_train()
     captured = capsys.readouterr()
     assert expected_result in captured.out
+
+    if deployer == "tfjob":
+        if cleanup:
+            assert expected_result not in str(get_tfjobs_with_labels('pytest-id=' + expected_result))
+        else:
+            assert expected_result in str(get_tfjobs_with_labels('pytest-id=' + expected_result))
+
+
 
 def test_job_deployer(capsys):
     run_submission_with_function_preprocessor(capsys, deployer="job")    
 
 def test_tfjob_deployer(capsys):
     run_submission_with_function_preprocessor(capsys, deployer="tfjob", namespace="kubeflow") 
+
+def test_tfjob_deployer_cleanup(capsys, caplog):
+    run_submission_with_function_preprocessor(capsys, deployer="tfjob",
+                                              namespace="kubeflow", cleanup=True)
 
 def test_docker_builder(capsys):
     run_submission_with_function_preprocessor(capsys, builder="docker")    


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add a option to let user cleanup tfjob after tfjobs finishes.

**Which issue(s) this PR fixes** :
Fixes #239

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/311)
<!-- Reviewable:end -->
