### PR TITLE
Upgrading ks version for e2e testing

### DIFF
--- a/tests/workflows/app.yaml
+++ b/tests/workflows/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: 0.1.0
+apiVersion: 0.3.0
 environments:
   releasing:
     destination:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes an issue in E2E test where ks was failing to fetch an old swagger spec. Upgrading the apiversion seems to fix the issue.

```

INFO|2019-07-11T18:51:43|/src/kubeflow/testing/py/kubeflow/testing/util.py|71| level=error msg="find objects: Received status code '404' when trying to retrieve OpenAPI schema for cluster version 'v0.3.1' from URL 'https://raw.githubusercontent.com/kubernetes/kubernetes/v0.3.1/api/openapi-spec/swagger.json'"
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 417, in <module>
    final_result = main()
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 407, in main
    return run(args, file_handler)
  File "/src/kubeflow/testing/py/kubeflow/testing/run_e2e_workflow.py", line 273, in run
    util.run([ks_cmd, "show", env, "-c", w.component], cwd=w.app_dir)
  File "/src/kubeflow/testing/py/kubeflow/testing/util.py", line 87, in run
    " ".join(command), process.returncode), "\n".join(output))
subprocess.CalledProcessError: Command 'cmd: ks show kubeflow-katib-presubmit-e2e-v1alpha1-681-9773511-5616-aafa -c workflows-v1alpha1 exited with code 1' returned non-zero exit status 1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/313)
<!-- Reviewable:end -->
