### PR TITLE
Specifying exact container while log tailing

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,7 @@ ARG CLOUD_SDK_VERSION="236.0.0"
 # Install pinned version of gcloud
 RUN mkdir -p /builder && \
 	wget -qO- https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz | tar zx -C /builder && \
-	CLOUDSDK_PYTHON="python3.5" /builder/google-cloud-sdk/install.sh --usage-reporting=false \
+	CLOUDSDK_PYTHON="python2" /builder/google-cloud-sdk/install.sh --usage-reporting=false \
 		--bash-completion=false \
 		--disable-installation-options && \
 	rm -rf ~/.config/gcloud

--- a/fairing/builders/cluster/cluster.py
+++ b/fairing/builders/cluster/cluster.py
@@ -84,7 +84,8 @@ class ClusterBuilder(BaseBuilder):
         self.manager.log(
             name=created_pod.metadata.name,
             namespace=created_pod.metadata.namespace,
-            selectors=labels)
+            selectors=labels,
+            container="kaniko")
 
         # clean up created pod and secret
         self.context_source.cleanup()

--- a/fairing/deployers/job/job.py
+++ b/fairing/deployers/job/job.py
@@ -109,7 +109,10 @@ class Job(DeployerInterface):
         )
 
     def get_logs(self):
-        self.backend.log(self._created_job.metadata.name, self._created_job.metadata.namespace, self.labels)
+        self.backend.log(self._created_job.metadata.name,
+                         self._created_job.metadata.namespace,
+                         self.labels,
+                         container="fairing-job")
 
         if self.cleanup:
             self.do_cleanup()

--- a/fairing/deployers/tfjob/tfjob.py
+++ b/fairing/deployers/tfjob/tfjob.py
@@ -66,4 +66,4 @@ class TfJob(Job):
             'tf-replica-type': 'worker',
             'tf-job-name': name
         }
-        self.backend.log(name, namespace, labels)
+        self.backend.log(name, namespace, labels, container="tensorflow")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Specifies the container name when tailing logs after a resource is deployed. Currently we don't specify the name of the container and that works if only one container is present in the pod but in environment like ISTIO, where a sidecar container is present, the tailing functionality breaks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #316 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/317)
<!-- Reviewable:end -->
