### PR TITLE
Defaulting to current namespace instead of kubeflow namespace and other minor changes

### DIFF
--- a/examples/prediction/xgboost-high-level-apis.ipynb
+++ b/examples/prediction/xgboost-high-level-apis.ipynb
@@ -214,9 +214,7 @@
     "# Setting up google container repositories (GCR) for storing output containers\n",
     "# You can use any docker container registry istead of GCR\n",
     "GCP_PROJECT = fairing.cloud.gcp.guess_project_name()\n",
-    "DOCKER_REGISTRY = 'gcr.io/{}/fairing-job'.format(GCP_PROJECT)\n",
-    "PY_VERSION = \".\".join([str(x) for x in sys.version_info[0:3]])\n",
-    "BASE_IMAGE = 'python:{}'.format(PY_VERSION)"
+    "DOCKER_REGISTRY = 'gcr.io/{}/fairing-job'.format(GCP_PROJECT)"
    ]
   },
   {
@@ -238,7 +236,7 @@
    "source": [
     "from fairing import TrainJob\n",
     "from fairing.backends import KubeflowGKEBackend\n",
-    "train_job = TrainJob(HousingServe, BASE_IMAGE, input_files=['ames_dataset/train.csv', \"requirements.txt\"],\n",
+    "train_job = TrainJob(HousingServe, input_files=['ames_dataset/train.csv', \"requirements.txt\"],\n",
     "                     docker_registry=DOCKER_REGISTRY, backend=KubeflowGKEBackend())\n",
     "train_job.submit()"
    ]
@@ -262,7 +260,7 @@
    "source": [
     "from fairing import TrainJob\n",
     "from fairing.backends import GCPManagedBackend\n",
-    "train_job = TrainJob(HousingServe, BASE_IMAGE, input_files=['ames_dataset/train.csv', \"requirements.txt\"],\n",
+    "train_job = TrainJob(HousingServe, input_files=['ames_dataset/train.csv', \"requirements.txt\"],\n",
     "                     docker_registry=DOCKER_REGISTRY, backend=GCPManagedBackend())\n",
     "train_job.submit()"
    ]
@@ -286,7 +284,7 @@
    "source": [
     "from fairing import PredictionEndpoint\n",
     "from fairing.backends import KubeflowGKEBackend\n",
-    "endpoint = PredictionEndpoint(HousingServe, BASE_IMAGE, input_files=['trained_ames_model.dat', \"requirements.txt\"],\n",
+    "endpoint = PredictionEndpoint(HousingServe, input_files=['trained_ames_model.dat', \"requirements.txt\"],\n",
     "                              docker_registry=DOCKER_REGISTRY, backend=KubeflowGKEBackend())\n",
     "endpoint.create()"
    ]
@@ -345,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/fairing/builders/cluster/cluster.py
+++ b/fairing/builders/cluster/cluster.py
@@ -3,6 +3,7 @@ import uuid
 
 from kubernetes import client
 
+import fairing
 from fairing.builders.base_builder import BaseBuilder
 from fairing.builders import dockerfile
 from fairing.constants import constants
@@ -34,7 +35,7 @@ class ClusterBuilder(BaseBuilder):
                  push=True,
                  base_image=constants.DEFAULT_BASE_IMAGE,
                  pod_spec_mutators=None,
-                 namespace="kubeflow",
+                 namespace=None,
                  dockerfile_path=None):
         super().__init__(
                 registry=registry,
@@ -48,7 +49,7 @@ class ClusterBuilder(BaseBuilder):
             raise RuntimeError("context_source is not specified")
         self.context_source = context_source
         self.pod_spec_mutators = pod_spec_mutators or []
-        self.namespace = namespace
+        self.namespace = namespace or fairing.utils.get_default_target_namespace()
 
     def build(self):
         logging.info("Building image using cluster builder.")

--- a/fairing/builders/cluster/gcs_context.py
+++ b/fairing/builders/cluster/gcs_context.py
@@ -36,16 +36,15 @@ class GCSContextSource(ContextSourceInterface):
     def generate_pod_spec(self, image_name, push):
         args = ["--dockerfile=Dockerfile",
                           "--destination=" + image_name,
-                          "--context=" + self.uploaded_context_url]
+                          "--context=" + self.uploaded_context_url,
+                          "--cache=true"]
         if not push:
             args.append("--no-push")
         return client.V1PodSpec(
                 containers=[client.V1Container(
                     name='kaniko',
                     image='gcr.io/kaniko-project/executor:v0.7.0',
-                    args=["--dockerfile=Dockerfile",
-                          "--destination=" + image_name,
-                          "--context=" + self.uploaded_context_url],
+                    args=args,
                 )],
                 restart_policy='Never'
             )

--- a/fairing/frameworks/lightgbm.py
+++ b/fairing/frameworks/lightgbm.py
@@ -214,7 +214,7 @@ def generate_context_files(config, config_file_name, num_machines):
 def execute(config,
             docker_registry,
             base_image="gcr.io/kubeflow-fairing/lightgbm:latest",
-            namespace="kubeflow",
+            namespace=None,
             stream_log=True,
             cores_per_worker=None,
             memory_per_worker=None,
@@ -237,7 +237,9 @@ def execute(config,
         pod_spec_mutators: list of functions that is used to mutate the podsspec. e.g. fairing.cloud.gcp.add_gcp_credentials_if_exists
                            This can used to set things like volumes and security context.
     """
-
+    if not namespace and not fairing.utils.is_running_in_k8s():
+        namespace = "kubeflow"
+    namespace = namespace or fairing.utils.get_default_target_namespace()
     config_file_name = None
     if isinstance(config, str):
         config_file_name = config

--- a/fairing/ml_tasks/tasks.py
+++ b/fairing/ml_tasks/tasks.py
@@ -104,7 +104,7 @@ class PredictionEndpoint(BaseTask):
         }
         serialized_data = json.dumps(pdata)
         r = requests.post(self.url, data={'json':serialized_data})
-        logger.warning(r.text)
+        return json.loads(r.text)
 
     def delete(self):
         self._deployer.delete()

--- a/tests/integration/common/test_kubeflow_training.py
+++ b/tests/integration/common/test_kubeflow_training.py
@@ -45,7 +45,8 @@ def run_submission_with_function_preprocessor(capsys, deployer="job", builder="a
     if builder=='cluster':
         fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY,
                                    pod_spec_mutators=[fairing.cloud.gcp.add_gcp_credentials],
-                                   context_source=gcs_context.GCSContextSource(namespace=namespace))
+                                   context_source=gcs_context.GCSContextSource(namespace=namespace),
+                                   namespace=namespace)
     else:
         fairing.config.set_builder(builder, base_image=base_image, registry=DOCKER_REGISTRY)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Summary:
1. Fixes the default namespace in args from "kubeflow" to current namespace in multiple places. 
1. Correctly passes the build context in GKEBackend
1. Made changes to the XGBoost example to make use of new defaults in the API
1. Fixes #253 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #253 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/318)
<!-- Reviewable:end -->
