### PR TITLE
Avoid converting to different path if running preprocessor multiple times

### DIFF
--- a/fairing/preprocessors/converted_notebook.py
+++ b/fairing/preprocessors/converted_notebook.py
@@ -74,7 +74,7 @@ class ConvertNotebookPreprocessor(BasePreProcessor):
         contents, _ = exporter.from_filename(self.notebook_file)
         converted_notebook = Path(self.notebook_file).with_suffix('.py')
         if converted_notebook.exists() and not self.overwrite:
-            raise Exception('Default path {} has existed but overwrite flag is False'.format(converted_notebook))
+            raise Exception('Default path {} exists but overwrite flag is False'.format(converted_notebook))
         with open(converted_notebook, 'w') as f:
             f.write(contents)
         self.executable = converted_notebook
@@ -125,7 +125,7 @@ class ConvertNotebookPreprocessorWithFire(ConvertNotebookPreprocessor):
         contents = "\n".join(lines)
         converted_notebook = Path(self.notebook_file).with_suffix('.py')
         if converted_notebook.exists() and not self.overwrite:
-            raise Exception('Default path {} has existed but overwrite flag is False'.format(converted_notebook))
+            raise Exception('Default path {} exists but overwrite flag is False'.format(converted_notebook))
         with open(converted_notebook, 'w') as f:
             f.write(contents)
             f.write("\n")

--- a/fairing/preprocessors/converted_notebook.py
+++ b/fairing/preprocessors/converted_notebook.py
@@ -65,8 +65,12 @@ class ConvertNotebookPreprocessor(BasePreProcessor):
 
         self.notebook_file = notebook_file
         self.notebook_preprocessor = notebook_preprocessor
+        self.not_overwrite = False
 
     def preprocess(self):
+        if self.not_overwrite:
+            return [self.executable]
+        self.not_overwrite = True
         exporter = nbconvert.PythonExporter()
         exporter.register_preprocessor(self.notebook_preprocessor, enabled=True)
         contents, _ = exporter.from_filename(self.notebook_file)
@@ -101,8 +105,14 @@ class ConvertNotebookPreprocessorWithFire(ConvertNotebookPreprocessor):
             output_map=output_map)
 
         self.class_name = class_name
+        self.not_overwrite = False
 
     def preprocess(self):
+        if self.not_overwrite:
+            results =  [self.executable]
+            results.extend(self.input_files)
+            return results
+        self.not_overwrite = True
         exporter = nbconvert.PythonExporter()
         exporter.register_preprocessor(self.notebook_preprocessor, enabled=True)
         processed, _ = exporter.from_filename(self.notebook_file)

--- a/fairing/preprocessors/converted_notebook.py
+++ b/fairing/preprocessors/converted_notebook.py
@@ -109,7 +109,7 @@ class ConvertNotebookPreprocessorWithFire(ConvertNotebookPreprocessor):
 
     def preprocess(self):
         if self.not_overwrite:
-            results =  [self.executable]
+            results = [self.executable]
             results.extend(self.input_files)
             return results
         self.not_overwrite = True
@@ -148,6 +148,6 @@ if __name__ == "__main__":
   fire.Fire({0})
 """.format(self.class_name))
         self.executable = converted_notebook
-        results =  [converted_notebook]
+        results = [converted_notebook]
         results.extend(self.input_files)
         return results

--- a/fairing/preprocessors/converted_notebook.py
+++ b/fairing/preprocessors/converted_notebook.py
@@ -76,9 +76,9 @@ class ConvertNotebookPreprocessor(BasePreProcessor):
         contents, _ = exporter.from_filename(self.notebook_file)
         converted_notebook = Path(self.notebook_file).with_suffix('.py')
         if converted_notebook.exists():
-            dir_name = Path(self.notebook_file).parent
+            dir_name = Path(self.notebook_file).absolute().parent
             _, file_name = tempfile.mkstemp(suffix=".py", dir=dir_name)
-            converted_notebook = Path(file_name[file_name.find(str(dir_name)):])
+            converted_notebook = Path(file_name[file_name.rfind('/')+1:])
         with open(converted_notebook, 'w') as f:
             f.write(contents)
         self.executable = converted_notebook
@@ -133,9 +133,9 @@ class ConvertNotebookPreprocessorWithFire(ConvertNotebookPreprocessor):
         contents = "\n".join(lines)
         converted_notebook = Path(self.notebook_file).with_suffix('.py')
         if converted_notebook.exists():
-            dir_name = Path(self.notebook_file).parent
+            dir_name = Path(self.notebook_file).absolute().parent
             _, file_name = tempfile.mkstemp(suffix=".py", dir=dir_name)
-            converted_notebook = Path(file_name[file_name.find(str(dir_name)):])
+            converted_notebook = Path(file_name[file_name.rfind('/')+1:])
         with open(converted_notebook, 'w') as f:
             f.write(contents)
             f.write("\n")

--- a/fairing/preprocessors/converted_notebook.py
+++ b/fairing/preprocessors/converted_notebook.py
@@ -65,12 +65,12 @@ class ConvertNotebookPreprocessor(BasePreProcessor):
 
         self.notebook_file = notebook_file
         self.notebook_preprocessor = notebook_preprocessor
-        self.not_overwrite = False
+        self._not_overwrite = False
 
     def preprocess(self):
-        if self.not_overwrite:
+        if self._not_overwrite:
             return [self.executable]
-        self.not_overwrite = True
+        self._not_overwrite = True
         exporter = nbconvert.PythonExporter()
         exporter.register_preprocessor(self.notebook_preprocessor, enabled=True)
         contents, _ = exporter.from_filename(self.notebook_file)
@@ -105,14 +105,14 @@ class ConvertNotebookPreprocessorWithFire(ConvertNotebookPreprocessor):
             output_map=output_map)
 
         self.class_name = class_name
-        self.not_overwrite = False
+        self._not_overwrite = False
 
     def preprocess(self):
-        if self.not_overwrite:
+        if self._not_overwrite:
             results = [self.executable]
             results.extend(self.input_files)
             return results
-        self.not_overwrite = True
+        self._not_overwrite = True
         exporter = nbconvert.PythonExporter()
         exporter.register_preprocessor(self.notebook_preprocessor, enabled=True)
         processed, _ = exporter.from_filename(self.notebook_file)

--- a/tests/unit/preprocessors/test_converted_notebook_preprocessor.py
+++ b/tests/unit/preprocessors/test_converted_notebook_preprocessor.py
@@ -21,7 +21,7 @@ def test_preprocess():
     os.remove(converted_notebook_path)
     assert Path(converted_notebook_path) in files
 
-def test_not_overwrite_flag():
+def test_not_overwrite_file_for_multiple_runs():
     preprocessor = ConvertNotebookPreprocessor(notebook_file=NOTEBOOK_PATH)
     files = preprocessor.preprocess()
     files_should_not_overwrite = preprocessor.preprocess()

--- a/tests/unit/preprocessors/test_converted_notebook_preprocessor.py
+++ b/tests/unit/preprocessors/test_converted_notebook_preprocessor.py
@@ -21,6 +21,14 @@ def test_preprocess():
     os.remove(converted_notebook_path)
     assert Path(converted_notebook_path) in files
 
+def test_not_overwrite_flag():
+    preprocessor = ConvertNotebookPreprocessor(notebook_file=NOTEBOOK_PATH)
+    files = preprocessor.preprocess()
+    files_should_not_overwrite = preprocessor.preprocess()
+    converted_notebook_path = posixpath.join(os.path.dirname(NOTEBOOK_PATH), os.path.basename(preprocessor.executable))
+    os.remove(converted_notebook_path)
+    assert files == files_should_not_overwrite
+
 def test_get_command():
     preprocessor = ConvertNotebookPreprocessor(notebook_file=NOTEBOOK_PATH)
     preprocessor.preprocess()

--- a/tests/unit/preprocessors/test_converted_notebook_preprocessor.py
+++ b/tests/unit/preprocessors/test_converted_notebook_preprocessor.py
@@ -21,13 +21,13 @@ def test_preprocess():
     os.remove(converted_notebook_path)
     assert Path(converted_notebook_path) in files
 
-def test_not_overwrite_file_for_multiple_runs():
+def test_overwrite_file_for_multiple_runs():
     preprocessor = ConvertNotebookPreprocessor(notebook_file=NOTEBOOK_PATH)
     files = preprocessor.preprocess()
-    files_should_not_overwrite = preprocessor.preprocess()
+    files_overwrite = preprocessor.preprocess()
     converted_notebook_path = posixpath.join(os.path.dirname(NOTEBOOK_PATH), os.path.basename(preprocessor.executable))
     os.remove(converted_notebook_path)
-    assert files == files_should_not_overwrite
+    assert files == files_overwrite
 
 def test_get_command():
     preprocessor = ConvertNotebookPreprocessor(notebook_file=NOTEBOOK_PATH)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- Avoid converting to different path if we run preprocessors multiple times
- Change path to the absolute path to fix path error like converting notebook to ".py"

**Which issue(s) this PR fixes**:
Fixes #319 

/assign @jlewi 
/assign @zhenghuiwang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/320)
<!-- Reviewable:end -->
