### PR TITLE
support mounting pvc for job deployer

### DIFF
--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -82,8 +82,9 @@ class KubernetesBackend(BackendInterface):
     def get_training_deployer(self, pod_spec_mutators = None):
         return Job(self._namespace, pod_spec_mutators=pod_spec_mutators)
     
-    def get_serving_deployer(self, model_class, service_type='LoadBalancer'):
-        return Serving(model_class, namespace=self._namespace, service_type=service_type)
+    def get_serving_deployer(self, model_class, service_type='LoadBalancer', pod_spec_mutators=None):
+        return Serving(model_class, namespace=self._namespace, service_type=service_type,
+                       pod_spec_mutators=pod_spec_mutators)
 
 class GKEBackend(KubernetesBackend):
 
@@ -131,8 +132,9 @@ class GKEBackend(KubernetesBackend):
         pod_spec_mutators.append(gcp.add_gcp_credentials_if_exists)
         return Job(namespace=self._namespace, pod_spec_mutators=pod_spec_mutators)
     
-    def get_serving_deployer(self, model_class, service_type='LoadBalancer'):
-        return Serving(model_class, namespace=self._namespace, service_type=service_type)
+    def get_serving_deployer(self, model_class, service_type='LoadBalancer', pod_spec_mutators=None):
+        return Serving(model_class, namespace=self._namespace, service_type=service_type,
+                       pod_spec_mutators=pod_spec_mutators)
 
     def get_docker_registry(self):
         return fairing.cloud.gcp.get_default_docker_registry()
@@ -160,8 +162,8 @@ class AWSBackend(KubernetesBackend):
         pod_spec_mutators.append(aws.add_aws_credentials_if_exists)
         return Job(namespace=self._namespace, pod_spec_mutators=pod_spec_mutators)
 
-    def get_serving_deployer(self, model_class):
-        return Serving(model_class, namespace=self._namespace)
+    def get_serving_deployer(self, model_class, pod_spec_mutators=None):
+        return Serving(model_class, namespace=self._namespace, pod_spec_mutators=pod_spec_mutators)
 
 class KubeflowBackend(KubernetesBackend):
 
@@ -217,7 +219,7 @@ class GCPManagedBackend(BackendInterface):
     def get_training_deployer(self, pod_spec_mutators = None):
         return GCPJob(self._project_id, self._region, self._training_scale_tier)
 
-    def get_serving_deployer(self, model_class):
+    def get_serving_deployer(self, model_class, pod_spec_mutators=None):
         # currently GCP serving deployer doesn't implement deployer interface
         raise NotImplementedError("GCP managed serving is not integrated into high level API yet.")
 

--- a/fairing/constants/constants.py
+++ b/fairing/constants/constants.py
@@ -38,3 +38,6 @@ KFSERVING_DEFAULT_NAME = 'fairing-kfserving-'
 KFSERVING_DEPLOYER_TYPE = 'kfservice'
 KFSERVING_CONTAINER_NAME = 'user-container'
 
+# persistent volume claim constants
+PVC_DEFAULT_MOUNT_PATH = '/mnt'
+PVC_DEFAULT_VOLUME_NAME = 'fairing-volume-'

--- a/fairing/ml_tasks/tasks.py
+++ b/fairing/ml_tasks/tasks.py
@@ -80,15 +80,16 @@ class TrainJob(BaseTask):
 class PredictionEndpoint(BaseTask):
 
     def __init__(self, model_class, base_docker_image=None, docker_registry=None, input_files=None, backend=None,
-                 service_type='LoadBalancer'):
+                 service_type='LoadBalancer', pod_spec_mutators=None):
         self.model_class = model_class
         self.service_type = service_type
-        super().__init__(model_class, base_docker_image, docker_registry, input_files, backend=backend)
+        super().__init__(model_class, base_docker_image, docker_registry, input_files, backend, pod_spec_mutators)
 
     def create(self):
         self._build()
         logging.info("Deploying the endpoint.")
-        self._deployer = self._backend.get_serving_deployer(self.model_class.__name__, service_type=self.service_type)
+        self._deployer = self._backend.get_serving_deployer(self.model_class.__name__, service_type=self.service_type,
+                                                            pod_spec_mutators=self._pod_spec_mutators)
         self.url = self._deployer.deploy(self.pod_spec)
         logger.warning("Prediction endpoint: {}".format(self.url))
 

--- a/tests/integration/onprem/test_pvc_mounting.py
+++ b/tests/integration/onprem/test_pvc_mounting.py
@@ -1,0 +1,115 @@
+import pytest
+import sys
+import io
+import tempfile
+import random
+import time
+import uuid
+import joblib
+import numpy as np
+
+from google.cloud import storage
+from kubernetes import client
+
+import fairing
+from fairing.constants import constants
+from fairing.kubernetes.utils import mounting_pvc
+
+
+GCS_PROJECT_ID = fairing.cloud.gcp.guess_project_name()
+DOCKER_REGISTRY = 'gcr.io/{}'.format(GCS_PROJECT_ID)
+
+# Dummy training function to be submitted
+def train_fn(msg):
+    for _ in range(30):
+        time.sleep(0.1)
+        print(msg)
+
+# Update module to work with function preprocessor
+# TODO: Remove when the function preprocessor works with functions from
+# other modules.
+train_fn.__module__ = '__main__'
+
+def get_job_with_labels(namespace,labels):
+        api_instance = client.BatchV1Api()
+        return api_instance.list_namespaced_job(
+                namespace,
+                label_selector=labels)
+
+def get_deployment_with_labels(namespace,labels):
+        api_instance = client.AppsV1Api()
+        return api_instance.list_namespaced_deployment(
+                namespace,
+                label_selector=labels)
+
+def submit_jobs_with_pvc(capsys, cleanup=False, namespace="default",
+                         pvc_name=None, pvc_mount_path=None):
+    py_version = ".".join([str(x) for x in sys.version_info[0:3]])
+    base_image = 'registry.hub.docker.com/library/python:{}'.format(py_version)
+    fairing.config.set_builder('append', base_image=base_image, registry=DOCKER_REGISTRY)
+
+    if pvc_mount_path:
+        pod_spec_mutators = [mounting_pvc(pvc_name=pvc_name, pvc_mount_path=pvc_mount_path)]
+    else:
+        pod_spec_mutators = [mounting_pvc(pvc_name=pvc_name)]
+
+    expected_result = str(uuid.uuid4())
+    fairing.config.set_deployer('job', namespace=namespace, cleanup=cleanup,
+                                labels={'pytest-id': expected_result}, stream_log=False,
+                                pod_spec_mutators=pod_spec_mutators)
+
+    remote_train = fairing.config.fn(lambda : train_fn(expected_result))
+    remote_train()
+    created_job = get_job_with_labels(namespace,'pytest-id=' + expected_result)
+    assert pvc_name == created_job.items[0].spec.template.spec.volumes[0].persistent_volume_claim.claim_name
+    if pvc_mount_path:
+        assert pvc_mount_path == created_job.items[0].spec.template.spec.containers[0].volume_mounts[0].mount_path
+    else:
+        assert constants.PVC_DEFAULT_MOUNT_PATH == created_job.items[0].spec.template.spec.containers[0].volume_mounts[0].mount_path
+
+class TestServe(object):
+  def __init__(self, model_file='test_model.dat'):
+    self.model = joblib.load(model_file)
+
+  def predict(self, X, feature_names):
+    prediction = self.model.predict(data=X)
+    return [[prediction.item(0), prediction.item(0)]]
+
+def submit_serving_with_pvc(capsys, namespace='default', pvc_name=None, pvc_mount_path=None):
+    fairing.config.set_builder('docker',
+      registry=DOCKER_REGISTRY,
+      base_image="seldonio/seldon-core-s2i-python3:0.4")
+
+    if pvc_mount_path:
+        pod_spec_mutators = [mounting_pvc(pvc_name=pvc_name, pvc_mount_path=pvc_mount_path)]
+    else:
+        pod_spec_mutators = [mounting_pvc(pvc_name=pvc_name)]
+
+    expected_result = str(uuid.uuid4())
+    fairing.config.set_deployer('serving', serving_class="TestServe",labels={'pytest-id': expected_result},
+                               pod_spec_mutators=pod_spec_mutators)
+    fairing.config.run()
+
+    created_deployment = get_deployment_with_labels(namespace,'pytest-id=' + expected_result)
+
+    assert pvc_name == created_deployment.items[0].spec.template.spec.volumes[0].persistent_volume_claim.claim_name
+    if pvc_mount_path:
+        assert pvc_mount_path == created_deployment.items[0].spec.template.spec.containers[0].volume_mounts[0].mount_path
+    else:
+        assert constants.PVC_DEFAULT_MOUNT_PATH == created_deployment.items[0].spec.template.spec.containers[0].volume_mounts[0].mount_path
+
+# test pvc mounting for Job
+def test_job_pvc_mounting(capsys):
+    submit_jobs_with_pvc(capsys, pvc_name='testpvc', pvc_mount_path='/pvcpath')
+
+# Test default mount path
+def test_job_pvc_mounting_without_path(capsys):
+    submit_serving_with_pvc(capsys, pvc_name='testpvc')
+
+# Test pvc mount for serving
+def test_serving_pvc_mounting(capsys):
+    submit_jobs_with_pvc(capsys, pvc_name='testpvc', pvc_mount_path='/pvcpath')
+
+# Test default mount path for serving
+def test_serving_pvc_mounting_without_path(capsys):
+    submit_serving_with_pvc(capsys, pvc_name='testpvc')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Support mount pvc to job deployer, so the trained model can be saved in the PVC derectly.


**Which issue(s) this PR fixes** :
Fixes #324 

**Special notes for your reviewer**:

From muy initial thoughts, that can be implemented by `pod_spec_mutators`, but checked the [adding mechanism](https://github.com/kubeflow/fairing/blob/4f9e007365101443e1230ee206980ed6014f7d31/fairing/deployers/job/job.py#L53) for `pod_spec_mutators`, that's hard to pass the args, but the `pvc_name` should be pass to job, so I updated the `Job` class to let user input `pvc_name` and `pvc_mount` (optional, defaults to `/mnt`).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
support mounting pvc for job deployer
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/325)
<!-- Reviewable:end -->
