### PR TITLE
fix mini message problems in conf

### DIFF
--- a/fairing/config.py
+++ b/fairing/config.py
@@ -70,7 +70,7 @@ class Config(object):
     def get_preprocessor(self):
         fn = preprocessor_map.get(self._preprocessor_name)
         if fn is None:
-            raise Exception('Builder name not found: {}\nAvailable deployer: {}'.format(
+            raise Exception('Preprocessor name not found: {}\nAvailable preprocessor: {}'.format(
                 self._preprocessor_name, list(preprocessor_map.keys())))
         return fn(**self._preprocessor_kwargs)
 
@@ -81,7 +81,7 @@ class Config(object):
     def get_builder(self, preprocessor):
         fn = builder_map.get(self._builder_name)
         if fn is None:
-            raise Exception('Builder name not found: {}\nAvailable deployer: {}'.format(
+            raise Exception('Builder name not found: {}\nAvailable builder: {}'.format(
                 self._builder_name, list(builder_map.keys())))
         return fn(preprocessor=preprocessor, **self._builder_kwargs)
 
@@ -102,6 +102,7 @@ class Config(object):
         builder = self.get_builder(preprocessor)
         logging.info("Using builder: %s", builder)
         deployer = self.get_deployer()
+        logging.info("Using deployer: %s", builder)
 
         builder.build()
         pod_spec = builder.generate_pod_spec()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When I set the unreasonable preprocessor incautiously, I got some error message (`Exception: Builder name not found: Python`) which confused me, checked details, there are some mini problems in the `fairing/config.py`, in fact, that's `preprocessor`, instead of `builder`, message problem. The PR is to fix the issue.
```
(python36) [root@jinchi1 kubeflow]# python main.py
Traceback (most recent call last):
  File "main.py", line 82, in <module>
    fairing.config.run()
  File "/opt/kubeflow/python3/python36/lib/python3.6/site-packages/fairing/config.py", line 99, in run
    preprocessor = self.get_preprocessor()
  File "/opt/kubeflow/python3/python36/lib/python3.6/site-packages/fairing/config.py", line 73, in get_preprocessor
    self._preprocessor_name, list(preprocessor_map.keys())))
Exception: Builder name not found: Python
Available deployer: ['python', 'notebook', 'full_notebook', 'function']
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/331)
<!-- Reviewable:end -->
