### PR TITLE
Disable istio injection for builder

### DIFF
--- a/fairing/builders/cluster/cluster.py
+++ b/fairing/builders/cluster/cluster.py
@@ -76,6 +76,7 @@ class ClusterBuilder(BaseBuilder):
                 generate_name="fairing-builder-",
                 labels=labels,
                 namespace=self.namespace,
+                annotations={"sidecar.istio.io/inject": "false"},
             ),
             spec=pod_spec
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes that fairing-builder causes an error on kubeflow installed on Amazon EKS when:

* it runs on istio-injection enabled namespace
* it uses EC2 instance profile to access ECR and S3

and turn off istio injection for fairing-builder pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #347

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/348)
<!-- Reviewable:end -->
