### PR TITLE
option to select tfjob version + adding annotation parameter

### DIFF
--- a/kubeflow/fairing/constants/constants.py
+++ b/kubeflow/fairing/constants/constants.py
@@ -1,3 +1,5 @@
+import os
+
 TEMP_TAR_GZ_FILENAME = '/tmp/fairing.layer.tar.gz'
 DEFAULT_IMAGE_NAME = 'fairing-job'
 DEFAULT_BASE_IMAGE = 'gcr.io/kubeflow-images-public/fairing:dev'
@@ -31,10 +33,10 @@ JOB_DEPLOPYER_TYPE = 'job'
 SERVING_DEPLOPYER_TYPE = 'serving'
 
 #TFJob Constants
+TF_JOB_VERSION = os.environ.get('TF_JOB_VERSION', 'v1beta2')
 TF_JOB_GROUP = "kubeflow.org"
 TF_JOB_KIND = "TFJob"
 TF_JOB_PLURAL = "tfjobs"
-TF_JOB_VERSION = "v1beta2"
 TF_JOB_DEFAULT_NAME = 'fairing-tfjob-'
 TF_JOB_DEPLOYER_TYPE = 'tfjob'
 

--- a/kubeflow/fairing/deployers/job/job.py
+++ b/kubeflow/fairing/deployers/job/job.py
@@ -12,8 +12,10 @@ from ..deployer import DeployerInterface
 
 logger = logging.getLogger(__name__)
 
+
 class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
     """Handle all the k8s' template building for a training
+
     Attributes:
         namespace: k8s namespace where the training's components
             will be deployed.
@@ -24,7 +26,7 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
     def __init__(self, namespace=None, runs=1, output=None,
                  cleanup=True, labels=None, job_name=constants.JOB_DEFAULT_NAME,
                  stream_log=True, deployer_type=constants.JOB_DEPLOPYER_TYPE,
-                 pod_spec_mutators=None):
+                 pod_spec_mutators=None, annotations=None):
         if namespace is None:
             self.namespace = utils.get_default_target_namespace()
         else:
@@ -40,7 +42,13 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
         self.cleanup = cleanup
         self.stream_log = stream_log
         self.set_labels(labels, deployer_type)
+        self.set_anotations(annotations)
         self.pod_spec_mutators = pod_spec_mutators or []
+
+    def set_anotations(self, annotations):
+        self.annotations = {'cluster-autoscaler.kubernetes.io/safe-to-evict': 'false'}
+        if annotations:
+            self.annotations.update(annotations)
 
     def set_labels(self, labels, deployer_type):
         self.labels = {'fairing-deployer': deployer_type}
@@ -80,7 +88,8 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
             raise TypeError('pod_spec must be a V1PodSpec, but got %s'
                             % type(pod_spec))
         return k8s_client.V1PodTemplateSpec(
-            metadata=k8s_client.V1ObjectMeta(name="fairing-deployer", labels=self.labels),
+            metadata=k8s_client.V1ObjectMeta(name="fairing-deployer", annotations=self.annotations,
+                                             labels=self.labels),
             spec=pod_spec)
 
     def generate_deployment_spec(self, pod_template_spec):

--- a/kubeflow/fairing/deployers/job/job.py
+++ b/kubeflow/fairing/deployers/job/job.py
@@ -46,7 +46,7 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
         self.pod_spec_mutators = pod_spec_mutators or []
 
     def set_anotations(self, annotations):
-        self.annotations = {'cluster-autoscaler.kubernetes.io/safe-to-evict': 'false'}
+        self.annotations = {}
         if annotations:
             self.annotations.update(annotations)
 

--- a/kubeflow/fairing/kubernetes/manager.py
+++ b/kubeflow/fairing/kubernetes/manager.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 MAX_STREAM_BYTES = 1024
 
+
 class KubeManager(object):
     """Handles communication with Kubernetes' client."""
 
@@ -48,7 +49,9 @@ class KubeManager(object):
             )
         except client.rest.ApiException:
             raise RuntimeError("Failed to create TFJob. Perhaps the CRD TFJob version "
-                               "{} in not installed?".format(constants.TF_JOB_VERSION))
+                               "{} in not installed(If you use different version you can pass it "
+                               "as ENV variable called "
+                               "`TF_JOB_VERSION`)?".format(constants.TF_JOB_VERSION))
 
     def delete_tf_job(self, name, namespace):
         """Delete the provided TFJob in the specified namespace.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We are running on v0.4.1 kubeflow and which is on the old version of tfjob operator. since you hardcoded the version we can not use deployer to create tfjob. This PR will provide a way to pass the version through env variable. It also adds  annotations parameter which we need to assign to the pods.

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/351)
<!-- Reviewable:end -->
