### PR TITLE
fix minor problems in tests

### DIFF
--- a/tests/integration/onprem/test_pvc_mounting.py
+++ b/tests/integration/onprem/test_pvc_mounting.py
@@ -74,7 +74,7 @@ def submit_jobs_with_pvc(capsys, cleanup=False, namespace="default", # pylint:di
             0].spec.template.spec.containers[0].volume_mounts[0].mount_path
 
 
-class TestServe(object):
+class MyTestServe(object):
     def __init__(self, model_file='test_model.dat'):
         self.model = joblib.load(model_file)
 
@@ -95,8 +95,9 @@ def submit_serving_with_pvc(capsys, namespace='default', pvc_name=None, pvc_moun
         pod_spec_mutators = [mounting_pvc(pvc_name=pvc_name)]
 
     expected_result = str(uuid.uuid4())
-    fairing.config.set_deployer('serving', serving_class="TestServe",
+    fairing.config.set_deployer('serving', serving_class="MyTestServe",
                                 labels={'pytest-id': expected_result},
+                                service_type='ClusterIP',
                                 pod_spec_mutators=pod_spec_mutators)
     fairing.config.run()
 
@@ -112,26 +113,22 @@ def submit_serving_with_pvc(capsys, namespace='default', pvc_name=None, pvc_moun
         assert constants.PVC_DEFAULT_MOUNT_PATH == created_deployment.items[
             0].spec.template.spec.containers[0].volume_mounts[0].mount_path
 
-# test pvc mounting for Job
-
 
 def test_job_pvc_mounting(capsys):
+    '''Test pvc mounting for Job'''
     submit_jobs_with_pvc(capsys, pvc_name='testpvc', pvc_mount_path='/pvcpath')
-
-# Test default mount path
 
 
 def test_job_pvc_mounting_without_path(capsys):
-    submit_serving_with_pvc(capsys, pvc_name='testpvc')
-
-# Test pvc mount for serving
-
-
-def test_serving_pvc_mounting(capsys):
-    submit_jobs_with_pvc(capsys, pvc_name='testpvc', pvc_mount_path='/pvcpath')
-
-# Test default mount path for serving
+    '''Test default mount path'''
+    submit_jobs_with_pvc(capsys, pvc_name='testpvc')
 
 
-def test_serving_pvc_mounting_without_path(capsys):
+def pass_test_serving_pvc_mounting(capsys):
+    '''Test pvc mount for serving'''
+    submit_serving_with_pvc(capsys, pvc_name='testpvc', pvc_mount_path='/pvcpath')
+
+
+def pass_test_serving_pvc_mounting_without_path(capsys):
+    '''Test default mount path for serving'''
     submit_serving_with_pvc(capsys, pvc_name='testpvc')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Find minor problems in tests during debuging the presummit timeout problem, since the PR #353 is closed, create new one to enhance that, thanks.

The main problem: in the `test_job_pvc_mounting_without_path` summits a serving and in the `pass_test_serving_pvc_mounting` simmits a job, should be a typo. And updated the serving type to ClusterIP since no need to loadblance for this cases. Thanks.


