### PR TITLE
Azure backend to work in custom namespaces

### DIFF
--- a/fairing/backends/backends.py
+++ b/fairing/backends/backends.py
@@ -185,8 +185,9 @@ class AWSBackend(KubernetesBackend):
 class AzureBackend(KubernetesBackend):
 
     def __init__(self, namespace=None, build_context_source=None):
-        build_context_source = build_context_source or azurestorage_context.StorageContextSource()
-        build_context_source.namespace = namespace
+        build_context_source = (
+            build_context_source or azurestorage_context.StorageContextSource(namespace=namespace)
+        )
         super(AzureBackend, self).__init__(namespace, build_context_source)
 
     def get_builder(self, preprocessor, base_image, registry,
@@ -228,7 +229,7 @@ class KubeflowAWSBackend(AWSBackend):
 
 class KubeflowAzureBackend(AzureBackend):
 
-    def __init__(self, namespace="kubeflow", build_context_source=None):
+    def __init__(self, namespace=None, build_context_source=None): # pylint:disable=useless-super-delegation
         super(KubeflowAzureBackend, self).__init__(namespace, build_context_source)
 
 

--- a/fairing/builders/cluster/azurestorage_context.py
+++ b/fairing/builders/cluster/azurestorage_context.py
@@ -8,8 +8,9 @@ from fairing.cloud import azure
 from fairing.constants import constants
 
 class StorageContextSource(ContextSourceInterface):
-    def __init__(self, region=None, resource_group_name=None, storage_account_name=None):
-        self.namespace = None
+    def __init__(self, namespace=None, region=None,
+                 resource_group_name=None, storage_account_name=None):
+        self.namespace = namespace or utils.get_default_target_namespace()
         self.region = region or "NorthEurope"
         self.resource_group_name = resource_group_name or "fairing"
         self.storage_account_name = storage_account_name or "fairing{}".format(


### PR DESCRIPTION
After this change, it is possible to use the Azure backend and storage
context in custom namespaces. Previously, the code was defaulting to
namespace `kubeflow` which might not be the right one in multi-user
multi-namespace setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/362)
<!-- Reviewable:end -->
