### PR TITLE
Use service type ClusterIP by default

### DIFF
--- a/examples/prediction/xgboost-high-level-apis.ipynb
+++ b/examples/prediction/xgboost-high-level-apis.ipynb
@@ -304,6 +304,7 @@
    "source": [
     "from kubeflow.fairing import PredictionEndpoint\n",
     "endpoint = PredictionEndpoint(HousingServe, input_files=['trained_ames_model.dat', \"requirements.txt\"],\n",
+    "                              service_type='LoadBalancer',\n",
     "                              docker_registry=DOCKER_REGISTRY,\n",
     "                              backend=BackendClass(build_context_source=BuildContext))\n",
     "endpoint.create()"

--- a/kubeflow/fairing/backends/backends.py
+++ b/kubeflow/fairing/backends/backends.py
@@ -90,7 +90,7 @@ class KubernetesBackend(BackendInterface):
     def get_training_deployer(self, pod_spec_mutators=None):
         return Job(self._namespace, pod_spec_mutators=pod_spec_mutators)
 
-    def get_serving_deployer(self, model_class, service_type='LoadBalancer', # pylint:disable=arguments-differ
+    def get_serving_deployer(self, model_class, service_type='ClusterIP', # pylint:disable=arguments-differ
                              pod_spec_mutators=None):
         return Serving(model_class, namespace=self._namespace, service_type=service_type,
                        pod_spec_mutators=pod_spec_mutators)
@@ -147,7 +147,7 @@ class GKEBackend(KubernetesBackend):
         pod_spec_mutators.append(gcp.add_gcp_credentials_if_exists)
         return Job(namespace=self._namespace, pod_spec_mutators=pod_spec_mutators)
 
-    def get_serving_deployer(self, model_class, service_type='LoadBalancer',
+    def get_serving_deployer(self, model_class, service_type='ClusterIP',
                              pod_spec_mutators=None):
         return Serving(model_class, namespace=self._namespace, service_type=service_type,
                        pod_spec_mutators=pod_spec_mutators)

--- a/kubeflow/fairing/deployers/serving/serving.py
+++ b/kubeflow/fairing/deployers/serving/serving.py
@@ -18,12 +18,8 @@ class Serving(Job):
 
     """
 
-    # TODO(https://github.com/kubeflow/fairing/issues/206): The default
-    # should be ClusterIP not LoadBalancer because LoadBalancer opens up
-    # a port. But this breaks the post submit test
-    # https://github.com/kubeflow/fairing/blob/master/examples/prediction/xgboost-high-level-apis.ipynb
     def __init__(self, serving_class, namespace=None, runs=1, labels=None,
-                 service_type="LoadBalancer", pod_spec_mutators=None):
+                 service_type="ClusterIP", pod_spec_mutators=None):
         super(Serving, self).__init__(namespace, runs,
                                       deployer_type=constants.SERVING_DEPLOPYER_TYPE,
                                       labels=labels)
@@ -62,7 +58,7 @@ class Serving(Job):
         else:
             # TODO(jlewi): The suffix won't always be cluster.local since
             # its configurable. Is there a way to get it programmatically?
-            url = "http://{0}.{1}.svc.cluster.local".format(
+            url = "http://{0}.{1}.svc.cluster.local:5000/predict".format(
                 self.service.metadata.name, self.service.metadata.namespace)
 
         logging.info("Cluster endpoint: %s", url)

--- a/kubeflow/fairing/ml_tasks/tasks.py
+++ b/kubeflow/fairing/ml_tasks/tasks.py
@@ -83,7 +83,7 @@ class TrainJob(BaseTask):
 class PredictionEndpoint(BaseTask):
 
     def __init__(self, model_class, base_docker_image=None, docker_registry=None, input_files=None,
-                 backend=None, service_type='LoadBalancer', pod_spec_mutators=None):
+                 backend=None, service_type='ClusterIP', pod_spec_mutators=None):
         self.model_class = model_class
         self.service_type = service_type
         super().__init__(model_class, base_docker_image, docker_registry,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #373 #206 

Not sure if this will break post-submit test. Please correct me if I miss something I don't know. 
With this fix, clusterIP svc url can be used for prediction. If `//github.com/kubeflow/fairing/blob/master/examples/prediction/xgboost-high-level-apis.ipynb` is tested in the same kubernetes cluster, it should work. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use service type ClusterIP by default
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/376)
<!-- Reviewable:end -->
