### PR TITLE
update kfserving version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+python-dateutil>=2.1,<=2.8.0
+numpy>=1.17.3
+kfserving>=0.2.1.1
 docker>=3.4.1
 notebook>=5.6.0
 kubernetes>=10.0.1
-kfserving==0.2.3
 future>=0.17.1
 six>=1.11.0
 google-cloud-storage>=1.13.2
@@ -13,7 +15,6 @@ oauth2client>=4.0.0
 tornado>=6.0.1
 google-api-python-client>=1.7.8
 cloudpickle>=0.8
-numpy>=1.14
 urllib3==1.24.2
 boto3>=1.9.0
 azure>=4.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kubeflow-fairing',
-    version='0.7.0',
+    version='0.7.0.1',
     author="Kubeflow Authors",
     author_email='hejinchi@cn.ibm.com',
     license="Apache License Version 2.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Because `kfserving` SDK version is changed to be consistent with kfserving release (0.2.1),  to avoid confusing user, made decision by kfserving comminication, drop old version, and release new one to align with kfserving current release. so kfserving new release is 0.2.1.0, update fairing accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/415)
<!-- Reviewable:end -->
