### PR TITLE
Test PyPI pre-releases but allow for failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
 dist: xenial # required for Python >= 3.7
 language: python
-# Python versions to test
-python:
-    - "3.7"
+
 # Command to install dependencies
 install:
-    - python setup.py install
-    - pip install --upgrade pytest
+  # NOTE: We install requirements explicitly with pip to avoid
+  # always installing packaged pre-releases as happens when we
+  # use setup.py to install our packages.
+  - pip install -r requirements.txt ${PIP_PRE_RELEASES:+--pre}
+  - python setup.py install
+  - pip install --upgrade pytest
+  - pip freeze
 # Command to run tests
 script:
-    - cd tests/unit
-    - pytest
+  - cd tests/unit
+  - pytest --verbose
+
+matrix:
+  include:
+    - python: 3.7
+      env: []
+    - python: 3.7
+      env: &allowed_failure_1 [PIP_PRE_RELEASES=True]
+  allow_failures:
+    - env: *allowed_failure_1
+  fast_finish: true


### PR DESCRIPTION
Using `python setup.py install` will install PyPI pre-releases of
packages while `pip install -r requirements.txt` won't do that. This
lead to CI tests failing as reported in #421. This commit updates the CI
build setup to run two parallell tests, one where we don't use
pre-releases and one where we do but allow them to fail and won't wait
on the run to complete either.

Fixes #421

**Special notes for your reviewer**:
- Closes #422 by providing an alternative approach. The difference was described here: https://github.com/kubeflow/fairing/pull/422#issuecomment-557010381
- I've come across this issue in another project as well where this approach was adopted for a ReadTheDocs build, for a trace to that see https://github.com/jupyterhub/kubespawner/issues/370#issuecomment-555622221.

**Release note**:

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/423)
<!-- Reviewable:end -->
