### PR TITLE
Correct the function's output alert message.

### DIFF
--- a/kubeflow/fairing/config.py
+++ b/kubeflow/fairing/config.py
@@ -124,7 +124,7 @@ class Config(object):
         builder = self.get_builder(preprocessor)
         logging.info("Using builder: %s", builder)
         deployer = self.get_deployer()
-        logging.info("Using deployer: %s", builder)
+        logging.info("Using deployer: %s", deployer)
 
         builder.build()
         pod_spec = builder.generate_pod_spec()


### PR DESCRIPTION
I got following out when execute the example under `fairing/examples/kfserving`:
```huleis-mbp:kfserving llhu$ python3 main.py 
Using preprocessor: <kubeflow.fairing.preprocessors.base.BasePreProcessor object at 0x10ef7c0f0>
Using builder:<kubeflow.fairing.builders.append.append.AppendBuilder object at 0x10ef7c208>
Using deployer:  <kubeflow.fairing.builders.append.append.AppendBuilder object at 0x10ef7c208>
```
The above `builder` and `deployer`'s log are same, In fact, it is logical output bug here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/429)
<!-- Reviewable:end -->
