### PR TITLE
Using Kubeflow-tfjob SDK to deploy TFJob

### DIFF
--- a/kubeflow/fairing/kubernetes/manager.py
+++ b/kubeflow/fairing/kubernetes/manager.py
@@ -4,6 +4,8 @@ import retrying
 from kubernetes import client, config, watch
 from kfserving import KFServingClient
 
+from kubeflow.tfjob import TFJobClient
+
 from kubeflow.fairing.utils import is_running_in_k8s
 from kubeflow.fairing.constants import constants
 
@@ -32,25 +34,19 @@ class KubeManager(object):
         api_instance = client.BatchV1Api()
         return api_instance.create_namespaced_job(namespace, job)
 
-    def create_tf_job(self, namespace, job):
+    def create_tf_job(self, namespace, tfjob):
         """Create the provided TFJob in the specified namespace.
         The TFJob version is defined in TF_JOB_VERSION in fairing.constants.
         The version TFJob need to be installed before creating the TFJob.
 
         :param namespace: The custom resource
-        :param job: The JSON schema of the Resource to create
+        :param tfjob: The JSON schema of the Resource to create
         :returns: object: Created TFJob.
 
         """
-        api_instance = client.CustomObjectsApi()
+        tfjob_client = TFJobClient()
         try:
-            return api_instance.create_namespaced_custom_object(
-                constants.TF_JOB_GROUP,
-                constants.TF_JOB_VERSION,
-                namespace,
-                constants.TF_JOB_PLURAL,
-                job
-            )
+            return tfjob_client.create(tfjob, namespace=namespace)
         except client.rest.ApiException:
             raise RuntimeError("Failed to create TFJob. Perhaps the CRD TFJob version "
                                "{} in not installed(If you use different version you can pass it "
@@ -65,14 +61,8 @@ class KubeManager(object):
         :returns: object: The deleted TFJob.
 
         """
-        api_instance = client.CustomObjectsApi()
-        return api_instance.delete_namespaced_custom_object(
-            constants.TF_JOB_GROUP,
-            constants.TF_JOB_VERSION,
-            namespace,
-            constants.TF_JOB_PLURAL,
-            name,
-            client.V1DeleteOptions())
+        tfjob_client = TFJobClient()
+        return tfjob_client.delete(name, namespace=namespace)
 
     def create_deployment(self, namespace, deployment):
         """Create an V1Deployment in the specified namespace.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ urllib3==1.24.2
 boto3>=1.9.0
 azure>=4.0.0
 retrying>=1.3.3
+kubeflow-tfjob>=0.1.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`Kubeflow-tfjob` SDK has been published, we should use the SDK to generate and deploy TFJob, see more in #434 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #434 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/435)
<!-- Reviewable:end -->
