### PR TITLE
executable passed to preprocessing should be treated as input file

### DIFF
--- a/kubeflow/fairing/preprocessors/base.py
+++ b/kubeflow/fairing/preprocessors/base.py
@@ -27,6 +27,8 @@ class BasePreProcessor(object):
         input_files = input_files or []
         command = command or ["python"]
         self.input_files = set([os.path.normpath(f) for f in input_files])
+        if self.executable is not None:
+            self.input_files.add(os.path.normpath(executable))
         output_map = output_map if output_map else {}
         normalized_map = {}
         for src, dst in output_map.items():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

### What this PR does
When the input file does not contain the executable file, the executable file is added to the input file.
If this PR is merged, the job can be executed by specifying only the executable file.


### Why we need it
The following code fails because the `executable` is not packed into the container.

https://github.com/kubeflow/fairing/blob/f8dd1518f2ac48a1e888eb7b12aae82b6f0959c6/examples/gcp/hello-world-gpu-pytorch.py#L25-L30

Only `input_files` are packed into the container.

https://github.com/kubeflow/fairing/blob/f8dd1518f2ac48a1e888eb7b12aae82b6f0959c6/kubeflow/fairing/preprocessors/base.py#L20-L25

I understand that there is a demand to run an executable that is already included in the base container.
However, in such cases, the preprocessor adds a prefix to "executable", so it must be specified with "command" instead of "executable".

For the above reasons, executables should be considered as files that are not included in the base container.

If so, we can treat `executable` as the default input file.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/445)
<!-- Reviewable:end -->
