### PR TITLE
Enhance the logging info output in the debug model

### DIFF
--- a/kubeflow/fairing/config.py
+++ b/kubeflow/fairing/config.py
@@ -16,8 +16,15 @@ from kubeflow.fairing.deployers.kfserving.kfserving import KFServing
 
 from kubeflow.fairing.notebook import notebook_util
 
+from kubeflow.fairing.constants import constants
+
 import logging
-logging.basicConfig(format='%(message)s')
+
+logging.basicConfig(
+    level=constants.FAIRING_LOG_LEVEL,
+    format=constants.FAIRING_LOG_FORMAT,
+    datefmt=constants.FAIRING_LOG_DATEFMT,
+)
 
 DEFAULT_PREPROCESSOR = 'python'
 DEFAULT_BUILDER = 'append'

--- a/kubeflow/fairing/constants/constants.py
+++ b/kubeflow/fairing/constants/constants.py
@@ -64,3 +64,8 @@ PVC_DEFAULT_VOLUME_NAME = 'fairing-volume-'
 
 # Kaniko Constants
 KANIKO_IMAGE = 'gcr.io/kaniko-project/executor:v0.14.0'
+
+#Fairing Logging Constants
+FAIRING_LOG_LEVEL = os.environ.get('FAIRING_LOG_LEVEL', 'INFO').upper()
+FAIRING_LOG_FORMAT = '%(levelname)s|%(asctime)s|%(pathname)s|%(lineno)d| %(message)s'
+FAIRING_LOG_DATEFMT = '%Y-%m-%d %H:%M:%S'

--- a/kubeflow/fairing/frameworks/lightgbm_dist_training_init.py
+++ b/kubeflow/fairing/frameworks/lightgbm_dist_training_init.py
@@ -1,9 +1,14 @@
+from kubeflow.fairing.constants import constants
+
 import importlib
 import argparse
 import logging
 
-logging.basicConfig(format='%(message)s')
-logging.getLogger().setLevel(logging.INFO)
+logging.basicConfig(
+    level=constants.FAIRING_LOG_LEVEL,
+    format=constants.FAIRING_LOG_FORMAT,
+    datefmt=constants.FAIRING_LOG_DATEFMT,
+)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Initializes environment for distributed LightGBM')


### PR DESCRIPTION
Our current debug info is so simple,especially, the confuse time stamp, also don't show the target debug file's location ,
[I 200108 13:36:53 config:131] Using preprocessor: <kubeflow.fairing.preprocessors.base.BasePreProcessor object at 0x1017af9b0>
after changed, it will be more meaningful, for example :
INFO|2020-01-08 13:18:33|/Users/llhu/Library/Python/3.7/lib/python/site-packages/werkzeug/_internal.py|122| * Running on http://127.0.0.1:8080/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/447)
<!-- Reviewable:end -->
