### PR TITLE
minio context source for vanilla k8s

### DIFF
--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -45,10 +45,17 @@ class MinioContextSource(ContextSourceInterface):
                                            args=["--dockerfile=Dockerfile",
                                                  "--destination=" + image_name,
                                                  "--context=" + self.uploaded_context_url],
-                                           env=[client.V1EnvVar(name='AWS_REGION',
-                                                                value=self.region_name)])],
-            restart_policy='Never')
-    
+                                           env=[client.V1EnvVar(name='AWS_REGION', value=self.region_name), 
+                                                client.V1EnvVar(name='AWS_ACCESS_KEY_ID', value=self.minio_secret), 
+                                                client.V1EnvVar(name='AWS_SECRET_ACCESS_KEY', value=self.minio_secret_key), 
+                                                client.V1EnvVar(name='S3_ENDPOINT', value=self.endpoint_url), 
+                                                client.V1EnvVar(name='S3_FORCE_PATH_STYLE', value="true")],
+                                           volume_mounts=[client.V1VolumeMount(name="docker-config",
+                                                                             mount_path="/kaniko/.docker/")],
+                                          )],
+                                        restart_policy='Never',
+                                        volumes=[client.V1Volume(name="docker-config", 
+                                                                 config_map=client.V1ConfigMapVolumeSource(name="docker-config"))])
     def cleanup(self):
-        #TODO(swiftdiaries)
+        # TODO(swiftdiaries)
         pass

--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -1,0 +1,54 @@
+from kubeflow.fairing.builders.cluster.context_source import ContextSourceInterface
+from kubeflow.fairing.cloud import k8s
+from kubeflow.fairing.kubernetes.manager import client, KubeManager
+from kubeflow.fairing import utils
+from kubeflow.fairing import constants
+
+constants.constants.KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v0.14.0"
+
+class MinioContextSource(ContextSourceInterface):
+    def __init__(self,
+                endpoint_url,
+                minio_secret,
+                minio_secret_key,
+                region_name):
+        self.endpoint_url = endpoint_url
+        self.minio_secret = minio_secret
+        self.minio_secret_key = minio_secret_key
+        self.region_name = region_name
+        self.Manager = KubeManager()
+        
+    def prepare(self, context_filename):
+        self.uploaded_context_url = self.upload_context(context_filename)
+        print(self.uploaded_context_url)
+
+    def upload_context(self, context_filename):
+        minio_uploader = k8s.MinioUploader(self.endpoint_url,
+                                      self.minio_secret,
+                                      self.minio_secret_key,
+                                      self.region_name)
+        context_hash = utils.crc(context_filename)
+        bucket_name = 'kubeflow-'+self.region_name
+        return minio_uploader.upload_to_bucket(blob_name='fairing-builds/'+context_hash,
+                                              bucket_name=bucket_name,
+                                              file_to_upload=context_filename)
+    def generate_pod_spec(self, image_name, push):
+        args = ["--dockerfile=Dockerfile",
+                "--destination=" + image_name,
+                "--context=" + self.uploaded_context_url]
+        if not push:
+            args.append("--no-push")
+
+        return client.V1PodSpec(
+            containers=[client.V1Container(name='kaniko',
+                                           image=constants.constants.KANIKO_IMAGE,
+                                           args=["--dockerfile=Dockerfile",
+                                                 "--destination=" + image_name,
+                                                 "--context=" + self.uploaded_context_url],
+                                           env=[client.V1EnvVar(name='AWS_REGION',
+                                                                value=self.region_name)])],
+            restart_policy='Never')
+    
+    def cleanup(self):
+        #TODO(swiftdiaries)
+        pass

--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -6,56 +6,81 @@ from kubeflow.fairing import constants
 
 constants.constants.KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v0.14.0"
 
+
 class MinioContextSource(ContextSourceInterface):
-    def __init__(self,
-                endpoint_url,
-                minio_secret,
-                minio_secret_key,
-                region_name):
+    def __init__(self, endpoint_url, minio_secret, minio_secret_key,
+                 region_name):
         self.endpoint_url = endpoint_url
         self.minio_secret = minio_secret
         self.minio_secret_key = minio_secret_key
         self.region_name = region_name
         self.Manager = KubeManager()
-        
-    def prepare(self, context_filename):
+
+    def prepare(self, context_filename):  # pylint: disable=arguments-differ
+        """
+        :param context_filename: context filename
+        """
         self.uploaded_context_url = self.upload_context(context_filename)
-        print(self.uploaded_context_url)
 
     def upload_context(self, context_filename):
         minio_uploader = k8s.MinioUploader(self.endpoint_url,
-                                      self.minio_secret,
-                                      self.minio_secret_key,
-                                      self.region_name)
+                                           self.minio_secret,
+                                           self.minio_secret_key,
+                                           self.region_name)
         context_hash = utils.crc(context_filename)
-        bucket_name = 'kubeflow-'+self.region_name
-        return minio_uploader.upload_to_bucket(blob_name='fairing-builds/'+context_hash,
-                                              bucket_name=bucket_name,
-                                              file_to_upload=context_filename)
-    def generate_pod_spec(self, image_name, push):
-        args = ["--dockerfile=Dockerfile",
-                "--destination=" + image_name,
-                "--context=" + self.uploaded_context_url]
+        bucket_name = 'kubeflow-' + self.region_name
+        return minio_uploader.upload_to_bucket(blob_name='fairing-builds/' +
+                                               context_hash,
+                                               bucket_name=bucket_name,
+                                               file_to_upload=context_filename)
+
+    def generate_pod_spec(self, image_name, push):  # pylint: disable=arguments-differ
+        """
+        :param image_name: name of image to be built
+        :param push: whether to push image to given registry or not
+        """
+        args = [
+            "--dockerfile=Dockerfile", "--destination=" + image_name,
+            "--context=" + self.uploaded_context_url
+        ]
         if not push:
             args.append("--no-push")
 
         return client.V1PodSpec(
-            containers=[client.V1Container(name='kaniko',
-                                           image=constants.constants.KANIKO_IMAGE,
-                                           args=["--dockerfile=Dockerfile",
-                                                 "--destination=" + image_name,
-                                                 "--context=" + self.uploaded_context_url],
-                                           env=[client.V1EnvVar(name='AWS_REGION', value=self.region_name), 
-                                                client.V1EnvVar(name='AWS_ACCESS_KEY_ID', value=self.minio_secret), 
-                                                client.V1EnvVar(name='AWS_SECRET_ACCESS_KEY', value=self.minio_secret_key), 
-                                                client.V1EnvVar(name='S3_ENDPOINT', value=self.endpoint_url), 
-                                                client.V1EnvVar(name='S3_FORCE_PATH_STYLE', value="true")],
-                                           volume_mounts=[client.V1VolumeMount(name="docker-config",
-                                                                             mount_path="/kaniko/.docker/")],
-                                          )],
-                                        restart_policy='Never',
-                                        volumes=[client.V1Volume(name="docker-config", 
-                                                                 config_map=client.V1ConfigMapVolumeSource(name="docker-config"))])
+            containers=[
+                client.V1Container(
+                    name='kaniko',
+                    image=constants.constants.KANIKO_IMAGE,
+                    args=[
+                        "--dockerfile=Dockerfile",
+                        "--destination=" + image_name,
+                        "--context=" + self.uploaded_context_url
+                    ],
+                    env=[
+                        client.V1EnvVar(name='AWS_REGION',
+                                        value=self.region_name),
+                        client.V1EnvVar(name='AWS_ACCESS_KEY_ID',
+                                        value=self.minio_secret),
+                        client.V1EnvVar(name='AWS_SECRET_ACCESS_KEY',
+                                        value=self.minio_secret_key),
+                        client.V1EnvVar(name='S3_ENDPOINT',
+                                        value=self.endpoint_url),
+                        client.V1EnvVar(name='S3_FORCE_PATH_STYLE',
+                                        value="true")
+                    ],
+                    volume_mounts=[
+                        client.V1VolumeMount(name="docker-config",
+                                             mount_path="/kaniko/.docker/")
+                    ],
+                )
+            ],
+            restart_policy='Never',
+            volumes=[
+                client.V1Volume(name="docker-config",
+                                config_map=client.V1ConfigMapVolumeSource(
+                                    name="docker-config"))
+            ])
+
     def cleanup(self):
         # TODO(swiftdiaries)
         pass

--- a/kubeflow/fairing/cloud/k8s.py
+++ b/kubeflow/fairing/cloud/k8s.py
@@ -1,33 +1,28 @@
 import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
-from kubeflow.fairing import utils
+
 
 class MinioUploader(object):
-    def __init__(self, 
-                 endpoint_url, 
-                 minio_secret, 
-                 minio_secret_key, 
+    def __init__(self, endpoint_url, minio_secret, minio_secret_key,
                  region_name):
 
         self.client = boto3.client('s3',
-                   endpoint_url=endpoint_url,
-                   aws_access_key_id=minio_secret,
-                   aws_secret_access_key=minio_secret_key,
-                   config=Config(signature_version='s3v4'),
-                   region_name=region_name,
-                   use_ssl=False)
+                                   endpoint_url=endpoint_url,
+                                   aws_access_key_id=minio_secret,
+                                   aws_secret_access_key=minio_secret_key,
+                                   config=Config(signature_version='s3v4'),
+                                   region_name=region_name,
+                                   use_ssl=False)
+
     def create_bucket(self, bucket_name):
         try:
             self.client.head_bucket(Bucket=bucket_name)
         except ClientError:
             bucket = {'Bucket': bucket_name}
             self.client.create_bucket(**bucket)
-    
-    def upload_to_bucket(self, 
-                     blob_name,
-                     bucket_name,
-                     file_to_upload):
+
+    def upload_to_bucket(self, blob_name, bucket_name, file_to_upload):
         self.create_bucket(bucket_name)
         self.client.upload_file(file_to_upload, bucket_name, blob_name)
         return "s3://{}/{}".format(bucket_name, blob_name)

--- a/kubeflow/fairing/cloud/k8s.py
+++ b/kubeflow/fairing/cloud/k8s.py
@@ -1,0 +1,33 @@
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+from kubeflow.fairing import utils
+
+class MinioUploader(object):
+    def __init__(self, 
+                 endpoint_url, 
+                 minio_secret, 
+                 minio_secret_key, 
+                 region_name):
+
+        self.client = boto3.client('s3',
+                   endpoint_url=endpoint_url,
+                   aws_access_key_id=minio_secret,
+                   aws_secret_access_key=minio_secret_key,
+                   config=Config(signature_version='s3v4'),
+                   region_name=region_name,
+                   use_ssl=False)
+    def create_bucket(self, bucket_name):
+        try:
+            self.client.head_bucket(Bucket=bucket_name)
+        except ClientError:
+            bucket = {'Bucket': bucket_name}
+            self.client.create_bucket(**bucket)
+    
+    def upload_to_bucket(self, 
+                     blob_name,
+                     bucket_name,
+                     file_to_upload):
+        self.create_bucket(bucket_name)
+        self.client.upload_file(file_to_upload, bucket_name, blob_name)
+        return "s3://{}/{}".format(bucket_name, blob_name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds a minio context source for the in-cluster builder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #456 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds a minio context source for in-cluster builder in vanilla k8s clusters.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/458)
<!-- Reviewable:end -->
