### PR TITLE
Fairing supports user specify the deployers name

### DIFF
--- a/kubeflow/fairing/deployers/job/job.py
+++ b/kubeflow/fairing/deployers/job/job.py
@@ -17,7 +17,7 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
     """Handle all the k8s' template building for a training"""
 
     def __init__(self, namespace=None, runs=1, output=None,
-                 cleanup=True, labels=None, job_name=constants.JOB_DEFAULT_NAME,
+                 cleanup=True, labels=None, job_name=None,
                  stream_log=True, deployer_type=constants.JOB_DEPLOPYER_TYPE,
                  pod_spec_mutators=None, annotations=None):
         """
@@ -141,9 +141,9 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
             api_version="batch/v1",
             kind="Job",
             metadata=k8s_client.V1ObjectMeta(
-                generate_name=self.job_name,
-                labels=self.labels,
-            ),
+                name=self.job_name,
+                generate_name=constants.JOB_DEFAULT_NAME,
+                labels=self.labels),
             spec=job_spec
         )
 

--- a/kubeflow/fairing/deployers/kfserving/kfserving.py
+++ b/kubeflow/fairing/deployers/kfserving/kfserving.py
@@ -44,7 +44,7 @@ class KFServing(DeployerInterface):
     def __init__(self, framework, default_storage_uri=None, canary_storage_uri=None,
                  canary_traffic_percent=0, namespace=None, labels=None, annotations=None,
                  custom_default_container=None, custom_canary_container=None,
-                 stream_log=False, cleanup=False):
+                 isvc_name=None, stream_log=False, cleanup=False):
         """
         :param framework: The framework for the InferenceService, such as Tensorflow,
             XGBoost and ScikitLearn etc.
@@ -59,10 +59,12 @@ class KFServing(DeployerInterface):
                                  provided containers.
         :param custom_canary_container: A flexible custom canary container for arbitrary customer
                                  provided containers.
+        :param isvc_name: The InferenceService name.
         :param stream_log: Show log or not when InferenceService started, defaults to True.
         :param cleanup: Delete the kfserving or not, defaults to False.
         """
         self.framework = framework
+        self.isvc_name = isvc_name
         self.default_storage_uri = default_storage_uri
         self.canary_storage_uri = canary_storage_uri
         self.canary_traffic_percent = canary_traffic_percent
@@ -153,6 +155,7 @@ class KFServing(DeployerInterface):
         return V1alpha2InferenceService(api_version=api_version,
                                         kind=constants.KFSERVING_KIND,
                                         metadata=k8s_client.V1ObjectMeta(
+                                            name=self.isvc_name,
                                             generate_name=constants.KFSERVING_DEFAULT_NAME,
                                             namespace=self.namespace),
                                         spec=isvc_spec)

--- a/kubeflow/fairing/deployers/pytorchjob/pytorchjob.py
+++ b/kubeflow/fairing/deployers/pytorchjob/pytorchjob.py
@@ -15,9 +15,8 @@ class PyTorchJob(Job):
     """ Handle all the k8s' template building to create pytorch
         training job using Kubeflow PyTorch Operator"""
     def __init__(self, namespace=None, master_count=1, worker_count=1,
-                 runs=1, job_name=constants.PYTORCH_JOB_DEFAULT_NAME,
-                 stream_log=True, labels=None, pod_spec_mutators=None,
-                 cleanup=False, annotations=None):
+                 runs=1, job_name=None, stream_log=True, labels=None,
+                 pod_spec_mutators=None, cleanup=False, annotations=None):
         """
 
         :param namespace: k8s namespace where the training's components
@@ -25,8 +24,8 @@ class PyTorchJob(Job):
         :param worker_count: Number of worker pods created for training job.
         :param master_count: Number of master pods created for training job.
         :param runs: number of runs
-        :param job_name: name of the job
-        :param stream_log: stream the log from deployed pytorchjob
+        :param job_name: name of the PytorchJob
+        :param stream_log: stream the log from deployed PytorchJob
         :param labels: labels to be assigned to the training job
         :param pod_spec_mutators: pod spec mutators (Default value = None)
         :param cleanup: clean up deletes components after job finished
@@ -73,7 +72,8 @@ class PyTorchJob(Job):
             api_version=constants.PYTORCH_JOB_GROUP + "/" + \
                 constants.PYTORCH_JOB_VERSION,
             kind=constants.PYTORCH_JOB_KIND,
-            metadata=k8s_client.V1ObjectMeta(generate_name=self.job_name,
+            metadata=k8s_client.V1ObjectMeta(name=self.job_name,
+                                             generate_name=constants.PYTORCH_JOB_DEFAULT_NAME,
                                              labels=self.labels),
             spec=V1PyTorchJobSpec(pytorch_replica_specs=pytorch_replica_specs)
         )

--- a/kubeflow/fairing/deployers/tfjob/tfjob.py
+++ b/kubeflow/fairing/deployers/tfjob/tfjob.py
@@ -15,7 +15,7 @@ class TfJob(Job):
     """ Handle all the k8s' template building to create tensorflow
         training job using Kubeflow TFOperator"""
     def __init__(self, namespace=None, worker_count=1, ps_count=0,
-                 chief_count=1, runs=1, job_name=constants.TF_JOB_DEFAULT_NAME, stream_log=True,
+                 chief_count=1, runs=1, job_name=None, stream_log=True,
                  labels=None, pod_spec_mutators=None, cleanup=False, annotations=None):
         """
 
@@ -25,7 +25,7 @@ class TfJob(Job):
         :param ps_count: Number of parameter set pods created for training job.
         :param chief_count: Number of Chief pods created for training job.
         :param runs: number of runs
-        :param job_name: name of the job
+        :param job_name: name of the TFJob
         :param stream_log: stream the log from deployed tfjob
         :param labels: labels to be assigned to the training job
         :param pod_spec_mutators: pod spec mutators (Default value = None)
@@ -77,7 +77,8 @@ class TfJob(Job):
         tfjob = V1TFJob(
             api_version=constants.TF_JOB_GROUP + "/" + constants.TF_JOB_VERSION,
             kind=constants.TF_JOB_KIND,
-            metadata=k8s_client.V1ObjectMeta(generate_name=self.job_name,
+            metadata=k8s_client.V1ObjectMeta(name=self.job_name,
+                                             generate_name=constants.TF_JOB_DEFAULT_NAME,
                                              labels=self.labels),
             spec=V1TFJobSpec(tf_replica_specs=tf_replica_specs)
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Sometimes, User needss to specify the deployers (Job, TFJob, PytorchJob and KFServing) name, the PR is going to support that.

The `generateName` is applied only if `Name` is not specified, so we can configure the `name` option, if the `name=None`, then the `generate_name` option will be applied.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes  #463 #462 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/466)
<!-- Reviewable:end -->
