### PR TITLE
Support user specified kubeconfig for remote k8s cluster in deployer

### DIFF
--- a/kubeflow/fairing/deployers/job/job.py
+++ b/kubeflow/fairing/deployers/job/job.py
@@ -19,7 +19,8 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
     def __init__(self, namespace=None, runs=1, output=None,
                  cleanup=True, labels=None, job_name=None,
                  stream_log=True, deployer_type=constants.JOB_DEPLOPYER_TYPE,
-                 pod_spec_mutators=None, annotations=None):
+                 pod_spec_mutators=None, annotations=None, config_file=None,
+                 context=None, client_configuration=None, persist_config=True):
         """
 
         :param namespace: k8s namespace where the training's components will be deployed.
@@ -32,6 +33,12 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
         :param stream_log: stream the log?
         :param deployer_type: type of deployer
         :param pod_spec_mutators: pod spec mutators (Default value = None)
+        :param config_file: kubeconfig file, defaults to ~/.kube/config. Note that for the case
+               that the SDK is running in cluster and you want to operate in another remote
+               cluster, user must set config_file to load kube-config file explicitly.
+        :param context: kubernetes context
+        :param client_configuration: The kubernetes.client.Configuration to set configs to.
+        :param persist_config: If True, config file will be updated when changed
         """
         if namespace is None:
             self.namespace = utils.get_default_target_namespace()
@@ -44,7 +51,11 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
         self.deployment_spec = None
         self.runs = runs
         self.output = output
-        self.backend = KubeManager()
+        self.backend = KubeManager(
+            config_file=config_file,
+            context=context,
+            client_configuration=client_configuration,
+            persist_config=persist_config)
         self.cleanup = cleanup
         self.stream_log = stream_log
         self.set_labels(labels, deployer_type)

--- a/kubeflow/fairing/deployers/kfserving/kfserving.py
+++ b/kubeflow/fairing/deployers/kfserving/kfserving.py
@@ -44,7 +44,8 @@ class KFServing(DeployerInterface):
     def __init__(self, framework, default_storage_uri=None, canary_storage_uri=None,
                  canary_traffic_percent=0, namespace=None, labels=None, annotations=None,
                  custom_default_container=None, custom_canary_container=None,
-                 isvc_name=None, stream_log=False, cleanup=False):
+                 isvc_name=None, stream_log=False, cleanup=False, config_file=None,
+                 context=None, client_configuration=None, persist_config=True):
         """
         :param framework: The framework for the InferenceService, such as Tensorflow,
             XGBoost and ScikitLearn etc.
@@ -62,6 +63,12 @@ class KFServing(DeployerInterface):
         :param isvc_name: The InferenceService name.
         :param stream_log: Show log or not when InferenceService started, defaults to True.
         :param cleanup: Delete the kfserving or not, defaults to False.
+        :param config_file: kubeconfig file, defaults to ~/.kube/config. Note that for the case
+               that the SDK is running in cluster and you want to operate in another remote
+               cluster, user must set config_file to load kube-config file explicitly.
+        :param context: kubernetes context
+        :param client_configuration: The kubernetes.client.Configuration to set configs to.
+        :param persist_config: If True, config file will be updated when changed
         """
         self.framework = framework
         self.isvc_name = isvc_name
@@ -74,7 +81,11 @@ class KFServing(DeployerInterface):
         self.custom_default_container = custom_default_container
         self.custom_canary_container = custom_canary_container
         self.stream_log = stream_log
-        self.backend = KubeManager()
+        self.backend = KubeManager(
+            config_file=config_file,
+            context=context,
+            client_configuration=client_configuration,
+            persist_config=persist_config)
 
         if namespace is None:
             self.namespace = utils.get_default_target_namespace()

--- a/kubeflow/fairing/deployers/pytorchjob/pytorchjob.py
+++ b/kubeflow/fairing/deployers/pytorchjob/pytorchjob.py
@@ -16,7 +16,9 @@ class PyTorchJob(Job):
         training job using Kubeflow PyTorch Operator"""
     def __init__(self, namespace=None, master_count=1, worker_count=1,
                  runs=1, job_name=None, stream_log=True, labels=None,
-                 pod_spec_mutators=None, cleanup=False, annotations=None):
+                 pod_spec_mutators=None, cleanup=False, annotations=None,
+                 config_file=None, context=None, client_configuration=None,
+                 persist_config=True):
         """
 
         :param namespace: k8s namespace where the training's components
@@ -30,11 +32,20 @@ class PyTorchJob(Job):
         :param pod_spec_mutators: pod spec mutators (Default value = None)
         :param cleanup: clean up deletes components after job finished
         :param annotations: annotations (Default value = None)
+        :param config_file: kubeconfig file, defaults to ~/.kube/config. Note that for the case
+               that the SDK is running in cluster and you want to operate in another remote
+               cluster, user must set config_file to load kube-config file explicitly.
+        :param context: kubernetes context
+        :param client_configuration: The kubernetes.client.Configuration to set configs to.
+        :param persist_config: If True, config file will be updated when changed
         """
         super(PyTorchJob, self).__init__(namespace, runs, job_name=job_name, stream_log=stream_log,
                                          deployer_type=constants.PYTORCH_JOB_DEPLOYER_TYPE,
                                          pod_spec_mutators=pod_spec_mutators, cleanup=cleanup,
-                                         labels=labels, annotations=annotations)
+                                         labels=labels, annotations=annotations,
+                                         config_file=config_file, context=context,
+                                         client_configuration=client_configuration,
+                                         persist_config=persist_config)
         self.distribution = {
             'Master': master_count,
             'Worker': worker_count,

--- a/kubeflow/fairing/deployers/tfjob/tfjob.py
+++ b/kubeflow/fairing/deployers/tfjob/tfjob.py
@@ -16,7 +16,8 @@ class TfJob(Job):
         training job using Kubeflow TFOperator"""
     def __init__(self, namespace=None, worker_count=1, ps_count=0,
                  chief_count=1, runs=1, job_name=None, stream_log=True,
-                 labels=None, pod_spec_mutators=None, cleanup=False, annotations=None):
+                 labels=None, pod_spec_mutators=None, cleanup=False, annotations=None,
+                 config_file=None, context=None, client_configuration=None, persist_config=True):
         """
 
         :param namespace: k8s namespace where the training's components
@@ -31,11 +32,19 @@ class TfJob(Job):
         :param pod_spec_mutators: pod spec mutators (Default value = None)
         :param cleanup: clean up deletes components after job finished
         :param annotations: annotations (Default value = None)
+        :param config_file: kubeconfig file, defaults to ~/.kube/config. Note that for the case
+               that the SDK is running in cluster and you want to operate in another remote
+               cluster, user must set config_file to load kube-config file explicitly.
+        :param context: kubernetes context
+        :param client_configuration: The kubernetes.client.Configuration to set configs to.
+        :param persist_config: If True, config file will be updated when changed
         """
         super(TfJob, self).__init__(namespace, runs, job_name=job_name, stream_log=stream_log,
                                     deployer_type=constants.TF_JOB_DEPLOYER_TYPE, labels=labels,
                                     pod_spec_mutators=pod_spec_mutators, cleanup=cleanup,
-                                    annotations=annotations)
+                                    annotations=annotations, config_file=config_file,
+                                    context=context, client_configuration=client_configuration,
+                                    persist_config=persist_config)
         self.distribution = {
             'Worker': worker_count,
             'PS': ps_count,

--- a/kubeflow/fairing/kubernetes/manager.py
+++ b/kubeflow/fairing/kubernetes/manager.py
@@ -18,11 +18,28 @@ MAX_STREAM_BYTES = 1024
 class KubeManager(object):
     """Handles communication with Kubernetes' client."""
 
-    def __init__(self):
-        if is_running_in_k8s():
-            config.load_incluster_config()
+    def __init__(self, config_file=None, context=None,
+                 client_configuration=None, persist_config=True):
+        """
+        :param config_file: kubeconfig file, defaults to ~/.kube/config. Note that for the case
+               that the SDK is running in cluster and you want to operate in another remote
+               cluster, user must set config_file to load kube-config file explicitly.
+        :param context: kubernetes context
+        :param client_configuration: The kubernetes.client.Configuration to set configs to.
+        :param persist_config: If True, config file will be updated when changed
+        """
+        self.config_file = config_file
+        self.context = context
+        self.client_configuration = client_configuration
+        self.persist_config = persist_config
+        if config_file or not is_running_in_k8s():
+            config.load_kube_config(
+                config_file=self.config_file,
+                context=self.context,
+                client_configuration=self.client_configuration,
+                persist_config=self.persist_config)
         else:
-            config.load_kube_config()
+            config.load_incluster_config()
 
     def create_job(self, namespace, job):
         """Creates a V1Job in the specified namespace.
@@ -45,7 +62,11 @@ class KubeManager(object):
         :returns: object: Created TFJob.
 
         """
-        tfjob_client = TFJobClient()
+        tfjob_client = TFJobClient(
+            config_file=self.config_file,
+            context=self.context,
+            client_configuration=self.client_configuration,
+            persist_config=self.persist_config)
         try:
             return tfjob_client.create(tfjob, namespace=namespace)
         except client.rest.ApiException:
@@ -62,7 +83,11 @@ class KubeManager(object):
         :returns: object: The deleted TFJob.
 
         """
-        tfjob_client = TFJobClient()
+        tfjob_client = TFJobClient(
+            config_file=self.config_file,
+            context=self.context,
+            client_configuration=self.client_configuration,
+            persist_config=self.persist_config)
         return tfjob_client.delete(name, namespace=namespace)
 
 
@@ -76,7 +101,11 @@ class KubeManager(object):
         :returns: object: Created TFJob.
 
         """
-        pytorchjob_client = PyTorchJobClient()
+        pytorchjob_client = PyTorchJobClient(
+            config_file=self.config_file,
+            context=self.context,
+            client_configuration=self.client_configuration,
+            persist_config=self.persist_config)
         try:
             return pytorchjob_client.create(pytorchjob, namespace=namespace)
         except client.rest.ApiException:
@@ -93,7 +122,11 @@ class KubeManager(object):
         :returns: object: The deleted PyTorchJob.
 
         """
-        pytorchjob_client = PyTorchJobClient()
+        pytorchjob_client = PyTorchJobClient(
+            config_file=self.config_file,
+            context=self.context,
+            client_configuration=self.client_configuration,
+            persist_config=self.persist_config)
         return pytorchjob_client.delete(name, namespace=namespace)
 
     def create_deployment(self, namespace, deployment):
@@ -115,7 +148,11 @@ class KubeManager(object):
         :returns: object: Created InferenceService.
 
         """
-        KFServing = KFServingClient()
+        KFServing = KFServingClient(
+            config_file=self.config_file,
+            context=self.context,
+            client_configuration=self.client_configuration,
+            persist_config=self.persist_config)
         try:
             created_isvc = KFServing.create(isvc, namespace=namespace)
             isvc_name = created_isvc['metadata']['name']
@@ -135,7 +172,11 @@ class KubeManager(object):
         :returns: object: The deleted InferenceService.
 
         """
-        KFServing = KFServingClient()
+        KFServing = KFServingClient(
+            config_file=self.config_file,
+            context=self.context,
+            client_configuration=self.client_configuration,
+            persist_config=self.persist_config)
         return KFServing.delete(name, namespace=namespace)
 
     def delete_job(self, name, namespace):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

If user is working in k8s cluster, but want to deploy in another remote cluster using Fairing, Fairing should supports load kube_config from user specified location, as Kubenertes Python API done below.

https://github.com/kubernetes-client/python-base/blob/d30f1e6fd4e2725aae04fa2f4982a4cfec7c682b/config/kube_config.py#L719

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #465 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/467)
<!-- Reviewable:end -->
