### PR TITLE
Fix duplicated code in cluster builder

### DIFF
--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -40,7 +40,8 @@ class MinioContextSource(ContextSourceInterface):
         :param push: whether to push image to given registry or not
         """
         args = [
-            "--dockerfile=Dockerfile", "--destination=" + image_name,
+            "--dockerfile=Dockerfile",
+            "--destination=" + image_name,
             "--context=" + self.uploaded_context_url
         ]
         if not push:
@@ -51,11 +52,7 @@ class MinioContextSource(ContextSourceInterface):
                 client.V1Container(
                     name='kaniko',
                     image=constants.constants.KANIKO_IMAGE,
-                    args=[
-                        "--dockerfile=Dockerfile",
-                        "--destination=" + image_name,
-                        "--context=" + self.uploaded_context_url
-                    ],
+                    args=args,
                     env=[
                         client.V1EnvVar(name='AWS_REGION',
                                         value=self.region_name),

--- a/kubeflow/fairing/builders/cluster/s3_context.py
+++ b/kubeflow/fairing/builders/cluster/s3_context.py
@@ -53,9 +53,7 @@ class S3ContextSource(ContextSourceInterface):
         return client.V1PodSpec(
             containers=[client.V1Container(name='kaniko',
                                            image=constants.KANIKO_IMAGE,
-                                           args=["--dockerfile=Dockerfile",
-                                                 "--destination=" + image_name,
-                                                 "--context=" + self.uploaded_context_url],
+                                           args=args,
                                            env=[client.V1EnvVar(name='AWS_REGION',
                                                                 value=self.region)])],
             restart_policy='Never')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix duplicated code in cluster builder. In s3_context.py and minio_context.py, defined args but does not use that, and the `push` option does not work. The PR is going to fix that, remove duplicated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/471)
<!-- Reviewable:end -->
