### PR TITLE
Add podman builder to support CRI-O runtime

### DIFF
--- a/examples/kubeflow/main_ocp.py
+++ b/examples/kubeflow/main_ocp.py
@@ -1,0 +1,84 @@
+# Copyright 2020 The Kubeflow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Trains and Evaluates the MNIST network using a feed dictionary."""
+import os
+
+from six.moves import xrange  # pylint: disable=redefined-builtin
+import tensorflow as tf
+from tensorflow.examples.tutorials.mnist import input_data
+from tensorflow.examples.tutorials.mnist import mnist
+
+
+INPUT_DATA_DIR = '/tmp/tensorflow/mnist/input_data/'
+MAX_STEPS = 2000
+BATCH_SIZE = 100
+LEARNING_RATE = 0.3
+HIDDEN_1 = 128
+HIDDEN_2 = 32
+
+# HACK: Ideally we would want to have a unique subpath for each instance of the job,
+#  but since we can't, we are instead appending HOSTNAME to the logdir
+LOG_DIR = os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
+                       'tensorflow/mnist/logs/fully_connected_feed/', os.getenv('HOSTNAME', ''))
+
+
+class TensorflowModel():
+    def train(self, **kwargs): #pylint:disable=unused-argument
+        tf.logging.set_verbosity(tf.logging.ERROR)
+        self.data_sets = input_data.read_data_sets(INPUT_DATA_DIR)
+        self.images_placeholder = tf.placeholder(
+            tf.float32, shape=(BATCH_SIZE, mnist.IMAGE_PIXELS))
+        self.labels_placeholder = tf.placeholder(tf.int32, shape=(BATCH_SIZE))
+
+        logits = mnist.inference(self.images_placeholder,
+                                 HIDDEN_1,
+                                 HIDDEN_2)
+
+        self.loss = mnist.loss(logits, self.labels_placeholder)
+        self.train_op = mnist.training(self.loss, LEARNING_RATE)
+        self.summary = tf.summary.merge_all()
+        init = tf.global_variables_initializer()
+        self.sess = tf.Session()
+        self.summary_writer = tf.summary.FileWriter(LOG_DIR, self.sess.graph)
+        self.sess.run(init)
+
+        data_set = self.data_sets.train
+        for step in xrange(MAX_STEPS):
+            images_feed, labels_feed = data_set.next_batch(BATCH_SIZE, False)
+            feed_dict = {
+                self.images_placeholder: images_feed,
+                self.labels_placeholder: labels_feed,
+            }
+
+            _, loss_value = self.sess.run([self.train_op, self.loss],
+                                          feed_dict=feed_dict)
+            if step % 100 == 0:
+                print("At step {}, loss = {}".format(step, loss_value))
+                summary_str = self.sess.run(self.summary, feed_dict=feed_dict)
+                self.summary_writer.add_summary(summary_str, step)
+                self.summary_writer.flush()
+
+
+if __name__ == '__main__':
+    if os.getenv('FAIRING_RUNTIME', None) is None:
+        from kubeflow import fairing
+        fairing.config.set_preprocessor('python', input_files=[__file__])
+        fairing.config.set_builder(name='podman', registry='<your-ocp-registry-name>',
+                                   base_image='tensorflow/tensorflow:1.13.1-py3')
+        fairing.config.run()
+    else:
+        remote_train = TensorflowModel()
+        remote_train.train()

--- a/kubeflow/fairing/builders/podman/podman.py
+++ b/kubeflow/fairing/builders/podman/podman.py
@@ -1,0 +1,111 @@
+import logging
+import os
+#from podman import Client
+
+from kubeflow.fairing.builders.base_builder import BaseBuilder
+from kubeflow.fairing.builders import dockerfile
+from kubeflow.fairing.constants import constants
+
+logger = logging.getLogger(__name__)
+
+
+class PodmanBuilder(BaseBuilder):
+    """A builder using the local Podman"""
+
+    def __init__(self,
+                 registry=None,
+                 image_name=constants.DEFAULT_IMAGE_NAME,
+                 base_image=constants.DEFAULT_BASE_IMAGE,
+                 preprocessor=None,
+                 push=True,
+                 dockerfile_path=None,
+                 tls_verify=False):
+        """
+        Initiate a Podman builder to build and publish images
+
+        :param registry:  a image registry to push image
+        :param image_name:  specify a name to the image built
+        :param base_image:  specify a base image
+        :param preprocessor:  a preprocessor to generate build command and context
+        :param push:  whether to publish image to registry
+        :param dockerfile_path:  specify the dockerfile path for image built
+        :param tls_verify:  when publishing image, whether to skip tls verify
+        """
+        super().__init__(
+            registry=registry,
+            image_name=image_name,
+            push=push,
+            base_image=base_image,
+            preprocessor=preprocessor,
+            dockerfile_path=dockerfile_path)
+        self.tls_verify = tls_verify
+
+    def build(self):
+        logging.info("Building image using podman")
+        #self.podman_client = Client()
+        self._build()
+        if self.push:
+            self.publish()
+
+    def _build(self):
+        """
+        build the podman image
+
+        see https://github.com/containers/libpod/blob/master/docs/source/markdown/podman-build.1.md
+        """
+        logger.warning('Building podman image {}...'.format(self.image_tag))
+
+        #TBD @mochiliu3000 Due to this issue, instead of using 'podman_client.images.build',
+        #call command line to build: https://github.com/containers/python-podman/issues/51
+
+        cmd_build = self.gen_cmd(option='build')
+        build_return = os.system(cmd_build)
+        if build_return != 0:
+            raise Exception('Image build failed')
+
+    def publish(self):
+        """
+        push the podman image to registry
+
+        see https://github.com/containers/libpod/blob/master/docs/source/markdown/podman-push.1.md
+        """
+        logger.warning('Publishing image {}...'.format(self.image_tag))
+
+        #TBD @mochiliu3000 Due to this issue, instead of using 'podman_client.image.push',
+        #call command line to push: https://github.com/containers/python-podman/issues/77
+
+        cmd_push = self.gen_cmd(option='publish')
+        push_return = os.system(cmd_push)
+        if push_return != 0:
+            raise Exception('Image push failed')
+
+    def gen_cmd(self, option):
+        """
+        generate podman cmd for builder and publisher
+
+        :param option:  options for which cmd to generate, 'build' or 'publish'
+        """
+        if option == 'build':
+            docker_command = self.preprocessor.get_command()
+            logger.warning("Podman command: {}".format(docker_command))
+            if not docker_command:
+                logger.warning("Not setting a command for the podman image.")
+            install_reqs_before_copy = self.preprocessor.is_requirements_txt_file_present()
+            if self.dockerfile_path:
+                dockerfile_path = self.dockerfile_path
+            else:
+                dockerfile_path = dockerfile.write_dockerfile(
+                    docker_command=docker_command,
+                    path_prefix=self.preprocessor.path_prefix,
+                    base_image=self.base_image,
+                    install_reqs_before_copy=install_reqs_before_copy)
+            self.preprocessor.output_map[dockerfile_path] = 'Dockerfile'
+            self.context_file, context_hash = self.preprocessor.context_tar_gz()
+            self.image_tag = self.full_image_name(context_hash)
+            cmd = 'podman build -t {} - < {}'.format(self.image_tag, self.context_file)
+        elif option == 'publish':
+            cmd = 'podman push {} --tls-verify={}' \
+                .format(self.image_tag, str(self.tls_verify).lower())
+        else:
+            raise Exception('Generate command failed with option - ' + option)
+        return cmd

--- a/kubeflow/fairing/config.py
+++ b/kubeflow/fairing/config.py
@@ -6,6 +6,7 @@ from kubeflow.fairing.preprocessors.function import FunctionPreProcessor
 from kubeflow.fairing.builders.append.append import AppendBuilder
 from kubeflow.fairing.builders.docker.docker import DockerBuilder
 from kubeflow.fairing.builders.cluster.cluster import ClusterBuilder
+from kubeflow.fairing.builders.podman.podman import PodmanBuilder
 
 from kubeflow.fairing.deployers.job.job import Job
 from kubeflow.fairing.deployers.serving.serving import Serving
@@ -41,6 +42,7 @@ builder_map = {
     'append': AppendBuilder,
     'docker': DockerBuilder,
     'cluster': ClusterBuilder,
+    'podman': PodmanBuilder
 }
 
 deployer_map = {

--- a/tests/unit/builders/test_podman.py
+++ b/tests/unit/builders/test_podman.py
@@ -1,0 +1,32 @@
+from os.path import isfile
+from kubeflow.fairing.preprocessors.base import BasePreProcessor
+from kubeflow.fairing.builders.podman.podman import PodmanBuilder
+
+MOCK_CMD_BUILD = 'podman build -t <image_tag> - < <context_file>'
+MOCK_CMD_PUSH = 'podman push <image_tag> --tls-verify=<tls_verify>'
+
+def test_podman_builder():
+    """
+    test podman builder
+    """
+    podmanBuilder = PodmanBuilder(
+        registry="test-image-registry",
+        preprocessor=BasePreProcessor(),
+        tls_verify=True)
+    cmd_build = podmanBuilder.gen_cmd('build')
+    cmd_push = podmanBuilder.gen_cmd('publish')
+
+    # Test docker context exists
+    assert isfile(podmanBuilder.context_file)
+
+    # Test if the podman build cmd is correct
+    mock_cmd_build = MOCK_CMD_BUILD \
+        .replace('<image_tag>', podmanBuilder.image_tag) \
+        .replace('<context_file>', podmanBuilder.context_file)
+    assert cmd_build == mock_cmd_build
+
+    # Test if the podman push cmd is correct
+    mock_cmd_push = MOCK_CMD_PUSH \
+        .replace('<image_tag>', podmanBuilder.image_tag) \
+        .replace('<tls_verify>', str(podmanBuilder.tls_verify).lower())
+    assert cmd_push == mock_cmd_push


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Environments like OCP 4 use CRI-O as default container runtime. In order to submit jobs to such environment, need to support podman builder to build image and push image to CRI-O based registry with/without TLS checking.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #472 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/474)
<!-- Reviewable:end -->
