### PR TITLE
Only use secure transport mode for new Azure Storage Accounts

### DIFF
--- a/kubeflow/fairing/cloud/azure.py
+++ b/kubeflow/fairing/cloud/azure.py
@@ -77,7 +77,8 @@ class AzureFileUploader(object):
             StorageAccountCreateParameters(
                 sku=Sku(name=SkuName.standard_ragrs),
                 kind=Kind.storage,
-                location=region
+                location=region,
+                enable_https_traffic_only=True
             )
         )
         return storage_async_operation.result()


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently Fairing creates new Storage Accounts on Azure (if necessary) that do not use best practices of enabling strict transport security. Azure Security Center will flag these storage accounts.

This PR uses the recommended default (which unfortunately isn't the default in the Python SDK).

References:
https://github.com/Azure-Samples/storage-python-manage#create-account
https://docs.microsoft.com/en-us/azure/storage/common/storage-require-secure-transfer
https://docs.microsoft.com/en-us/python/api/azure-mgmt-storage/azure.mgmt.storage.v2018_07_01.models.storageaccountcreateparameters?view=azure-python

**Release note**:
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/fairing/477)
<!-- Reviewable:end -->
