### PR TITLE
Change xgboost storage uri to reference storage_uri

### DIFF
--- a/kubeflow/fairing/deployers/kfserving/kfserving.py
+++ b/kubeflow/fairing/deployers/kfserving/kfserving.py
@@ -193,7 +193,7 @@ class KFServing(DeployerInterface):
                 tensorrt=V1alpha2TensorRTSpec(storage_uri=storage_uri))
         elif self.framework == 'xgboost':
             predictor = V1alpha2PredictorSpec(
-                xgboost=V1alpha2XGBoostSpec(storage_uri=V1alpha2XGBoostSpec))
+                xgboost=V1alpha2XGBoostSpec(storage_uri=storage_uri))
         elif self.framework == 'custom':
             predictor = V1alpha2PredictorSpec(
                 custom=V1alpha2CustomSpec(container=container))


### PR DESCRIPTION
V1alpha2XGBoostSpec call storage_uri parameter corrected to reference the `storage_uri` variable.

**Special notes for your reviewer**:

This was a copy-paste typo that's been corrected.  There is no issue raised for this bug, but it was stopping me from progressing my project.

**Release note**:
NONE

```release-note
NONE
```
