### PR TITLE
Updates Azure Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ google-api-python-client>=1.7.8
 cloudpickle>=0.8
 urllib3==1.24.2
 boto3>=1.9.0
-azure>=4.0.0
+azure-storage-file>=2.1.0
+azure-mgmt-storage>=9.0.0
 retrying>=1.3.3
 kubeflow-tfjob>=0.1.1
 kubeflow-pytorchjob>=0.1.1


### PR DESCRIPTION
The `azure` library is deprecated. This uses the correct libraries. This also has the side effect that a lot fewer azure dependencies are being installed. No code changes are necessary.

**Release note**:
No changes in functionality or behavior.
