### PR TITLE
Modify cluster builder example with minio context

### DIFF
--- a/examples/kubernetes-in-cluster-builder/main.py
+++ b/examples/kubernetes-in-cluster-builder/main.py
@@ -1,4 +1,4 @@
-# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
 from tensorflow.examples.tutorials.mnist import mnist
-
+import tarfile
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
 
 INPUT_DATA_DIR = '/tmp/tensorflow/mnist/input_data/'
-MAX_STEPS = 2000
+MAX_STEPS = 500
 BATCH_SIZE = 100
 LEARNING_RATE = 0.3
 HIDDEN_1 = 128
@@ -35,7 +38,20 @@ LOG_DIR = os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
                        'tensorflow/mnist/logs/fully_connected_feed/', os.getenv('HOSTNAME', ''))
 
 
-class MyModel(object):
+class MyModel():
+    def __init__(self, endpoint_url, secret_id, secret_key, \
+        region_name, bucket_name, blob_name):
+        self.model_path = '/tmp/myModel/'
+        if not os.path.exists(self.model_path):
+            os.mkdir(self.model_path)
+        self.model_tar_path = '/tmp/myModel.tar.gz'
+        self.s3_endpoint_url = endpoint_url
+        self.s3_secret_id = secret_id
+        self.s3_secret_key = secret_key
+        self.s3_region_name = region_name
+        self.s3_bucket_name = bucket_name
+        self.s3_blob_name = blob_name
+
     def train(self):
         self.data_sets = input_data.read_data_sets(INPUT_DATA_DIR)
         self.images_placeholder = tf.placeholder(
@@ -53,7 +69,7 @@ class MyModel(object):
         self.sess = tf.Session()
         self.summary_writer = tf.summary.FileWriter(LOG_DIR, self.sess.graph)
         self.sess.run(init)
-
+        # train
         data_set = self.data_sets.train
         for step in xrange(MAX_STEPS):
             images_feed, labels_feed = data_set.next_batch(BATCH_SIZE, False)
@@ -69,15 +85,72 @@ class MyModel(object):
                 summary_str = self.sess.run(self.summary, feed_dict=feed_dict)
                 self.summary_writer.add_summary(summary_str, step)
                 self.summary_writer.flush()
+        # save
+        saver = tf.train.Saver()
+        save_path = saver.save(self.sess, self.model_path + 'model.pb')
+        print('model saved to {}'.format(save_path))
+        self.sess.close()
 
+    def compress_model(self):
+        tar = tarfile.open(self.model_tar_path, "w:gz")
+        os.chdir(self.model_path)
+        for name in os.listdir("."):
+            tar.add(name)
+        tar.close()
+        print('model compressed to {}'.format(self.model_tar_path))
+
+    def upload_model_to_s3(self):
+        client = boto3.client('s3',
+                              endpoint_url=self.s3_endpoint_url,
+                              aws_access_key_id=self.s3_secret_id,
+                              aws_secret_access_key=self.s3_secret_key,
+                              config=Config(signature_version='s3v4'),
+                              region_name=self.s3_region_name,
+                              use_ssl=False)
+        try:
+            client.head_bucket(Bucket=self.s3_bucket_name)
+        except ClientError:
+            bucket = {'Bucket': self.s3_bucket_name}
+            client.create_bucket(**bucket)
+        client.upload_file(self.model_tar_path, self.s3_bucket_name, self.s3_blob_name)
+        print('model uploaded to s3://{}/{}'.format(self.s3_bucket_name, self.s3_blob_name))
+
+
+# To setup Minio, see
+# https://docs.min.io/docs/minio-quickstart-guide.html
+# To setup Minio Client, see
+# https://docs.min.io/docs/minio-client-quickstart-guide.html
+# To prepare docker config for Kanico, see
+# https://github.com/GoogleContainerTools/kaniko#pushing-to-docker-hub
 
 if __name__ == '__main__':
+    image_registry = '<image-registry>'   # e.g. index.docker.io/XXXX
+    s3_endpoint_url = '<s3-endpoint>'
+    s3_secret_id = '<s3-secret-id>'
+    s3_secret_key = '<s3-secret-key>'
+    s3_region = '<s3-region>'
+    s3_bucket_name = '<s3-bucket-name>'
+    s3_blob_name = '<s3-blob-name>'
+
     if os.getenv('FAIRING_RUNTIME', None) is None:
         from kubeflow import fairing
-        fairing.config.set_preprocessor('python', input_files=[__file__])
+        from kubeflow.fairing.builders.cluster.minio_context import MinioContextSource
+        minio_context_source = MinioContextSource(
+            endpoint_url=s3_endpoint_url,
+            minio_secret=s3_secret_id,
+            minio_secret_key=s3_secret_key,
+            region_name=s3_region)
+
+        fairing.config.set_preprocessor('python', input_files=[__file__, 'requirements.txt'])
         fairing.config.set_builder(
-            name='cluster', registry='<your-registry-here>')
+            name='cluster',
+            registry=image_registry,
+            context_source=minio_context_source,
+            cleanup=True)
         fairing.config.run()
     else:
-        remote_train = MyModel()
+        remote_train = MyModel(s3_endpoint_url, s3_secret_id, s3_secret_key, \
+            s3_region, s3_bucket_name, s3_blob_name)
         remote_train.train()
+        remote_train.compress_model()
+        remote_train.upload_model_to_s3()

--- a/examples/kubernetes-in-cluster-builder/requirements.txt
+++ b/examples/kubernetes-in-cluster-builder/requirements.txt
@@ -1,1 +1,2 @@
 tensorflow
+boto3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Since context_source is not optional now for cluster builder, the previous cluster builder example is updated to use minio context. This example also provides a way to save the model back to minio or s3 for further usage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #475

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
