### PR TITLE
Release kubeflow-fairing 0.7.2

### DIFF
--- a/kubeflow/fairing/__init__.py
+++ b/kubeflow/fairing/__init__.py
@@ -8,4 +8,4 @@ else:
 
 name = "fairing"
 
-__version__ = "0.7.0"
+__version__ = "0.7.2"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kubeflow-fairing',
-    version='0.7.1',
+    version='0.7.2',
     author="Kubeflow Authors",
     author_email='hejinchi@cn.ibm.com',
     license="Apache License Version 2.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

There is a problem about azure, that has been fixed in #482 . For now user cannot install `kubeflow-fairing`, we need to refresh the new package in pypi. Thanks.
