### PR TITLE
Use single snapshot to reduce build times

### DIFF
--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -42,7 +42,8 @@ class MinioContextSource(ContextSourceInterface):
         args = [
             "--dockerfile=Dockerfile",
             "--destination=" + image_name,
-            "--context=" + self.uploaded_context_url
+            "--context=" + self.uploaded_context_url,
+            "--single-snapshot"
         ]
         if not push:
             args.append("--no-push")


### PR DESCRIPTION
**What this PR does / why we need it**:

I have noticed that, when building with the cluster resource with large image layers, the multiple snapshots that are taken can add a **lot** amount of time to the build. You will  see these as the *Taking snapshot of full filesystem...* logs in the builder logs.

Using a single snapshot at the end of the process should shave quite a bit of time off the build/

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
```release-note
Reduce cluster build time with Kaniko by making use of "--single-snapshot" ability of executor.
```
