### PR TITLE
bump KANIKO_IMAGE to include important fixes

### DIFF
--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -4,7 +4,7 @@ from kubeflow.fairing.kubernetes.manager import client, KubeManager
 from kubeflow.fairing import utils
 from kubeflow.fairing import constants
 
-constants.constants.KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v0.14.0"
+constants.constants.KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v0.22.0"
 
 
 class MinioContextSource(ContextSourceInterface):

--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -4,8 +4,6 @@ from kubeflow.fairing.kubernetes.manager import client, KubeManager
 from kubeflow.fairing import utils
 from kubeflow.fairing import constants
 
-constants.constants.KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v0.22.0"
-
 
 class MinioContextSource(ContextSourceInterface):
     def __init__(self, endpoint_url, minio_secret, minio_secret_key,

--- a/kubeflow/fairing/constants/constants.py
+++ b/kubeflow/fairing/constants/constants.py
@@ -68,7 +68,7 @@ PVC_DEFAULT_MOUNT_PATH = '/mnt'
 PVC_DEFAULT_VOLUME_NAME = 'fairing-volume-'
 
 # Kaniko Constants
-KANIKO_IMAGE = 'gcr.io/kaniko-project/executor:v0.14.0'
+KANIKO_IMAGE = 'gcr.io/kaniko-project/executor:v0.22.0'
 
 #Fairing Logging Constants
 FAIRING_LOG_LEVEL = os.environ.get('FAIRING_LOG_LEVEL', 'INFO').upper()


### PR DESCRIPTION
**What this PR does / why we need it**:
There are fixes for these nasty apt-based bugs included into the current release. For instance, `BentoML` generated Dockerfiles cant build on current default `0.14.0`.

https://github.com/GoogleContainerTools/kaniko/issues/940
https://github.com/GoogleContainerTools/kaniko/issues/793

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

Updates Kaniko Executor default image to v0.22.0.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updates Kaniko Executor default image to v0.22.0.

```
