### PR TITLE
fix job deployer type-o

### DIFF
--- a/kubeflow/fairing/constants/constants.py
+++ b/kubeflow/fairing/constants/constants.py
@@ -33,7 +33,7 @@ DEFAULT_USER_AGENT = 'kubeflow-fairing/{VERSION}'
 
 # Job Constants
 JOB_DEFAULT_NAME = 'fairing-job-'
-JOB_DEPLOPYER_TYPE = 'job'
+JOB_DEPLOYER_TYPE = 'job'
 
 # Serving Constants
 SERVING_DEPLOPYER_TYPE = 'serving'

--- a/kubeflow/fairing/deployers/job/job.py
+++ b/kubeflow/fairing/deployers/job/job.py
@@ -18,7 +18,7 @@ class Job(DeployerInterface): #pylint:disable=too-many-instance-attributes
 
     def __init__(self, namespace=None, runs=1, output=None,
                  cleanup=True, labels=None, job_name=None,
-                 stream_log=True, deployer_type=constants.JOB_DEPLOPYER_TYPE,
+                 stream_log=True, deployer_type=constants.JOB_DEPLOYER_TYPE,
                  pod_spec_mutators=None, annotations=None, config_file=None,
                  context=None, client_configuration=None, persist_config=True):
         """


### PR DESCRIPTION
This type-o is confusing, but oddly consistent! This change just updates the constants spelling.