### PR TITLE
Fix bug for V1alpha2TensorRTSpec ImportError

### DIFF
--- a/kubeflow/fairing/deployers/kfserving/kfserving.py
+++ b/kubeflow/fairing/deployers/kfserving/kfserving.py
@@ -23,7 +23,7 @@ from kfserving import V1alpha2TensorflowSpec
 from kfserving import V1alpha2ONNXSpec
 from kfserving import V1alpha2PyTorchSpec
 from kfserving import V1alpha2SKLearnSpec
-from kfserving import V1alpha2TensorRTSpec
+from kfserving import V1alpha2TritonSpec
 from kfserving import V1alpha2XGBoostSpec
 from kfserving import V1alpha2CustomSpec
 from kfserving import V1alpha2InferenceServiceSpec
@@ -188,9 +188,9 @@ class KFServing(DeployerInterface):
         elif self.framework == 'sklearn':
             predictor = V1alpha2PredictorSpec(
                 sklearn=V1alpha2SKLearnSpec(storage_uri=storage_uri))
-        elif self.framework == 'tensorrt':
+        elif self.framework == 'triton':
             predictor = V1alpha2PredictorSpec(
-                tensorrt=V1alpha2TensorRTSpec(storage_uri=storage_uri))
+                triton=V1alpha2TritonSpec(storage_uri=storage_uri))
         elif self.framework == 'xgboost':
             predictor = V1alpha2PredictorSpec(
                 xgboost=V1alpha2XGBoostSpec(storage_uri=storage_uri))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil>=2.1,<=2.8.0
 numpy>=1.17.3
-kfserving>=0.2.1.1
+kfserving>=0.3.0.2
 docker>=3.4.1
 notebook>=5.6.0
 kubernetes==10.0.1
@@ -15,7 +15,7 @@ httplib2>=0.12.0
 oauth2client>=4.0.0
 tornado>=6.0.1
 google-api-python-client>=1.7.8
-cloudpickle>=0.8
+cloudpickle>=0.8,<=1.4.1
 urllib3==1.24.2
 boto3>=1.9.0
 azure-storage-file>=2.1.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix bug for V1alpha2TensorRTSpec ImportError
```
 from kfserving import V1alpha2TensorRTSpec
ImportError: cannot import name 'V1alpha2TensorRTSpec'
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubeflow/examples/issues/806

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
