### PR TITLE
Add --user option to pip install command to support non root user environment

### DIFF
--- a/kubeflow/fairing/builders/dockerfile.py
+++ b/kubeflow/fairing/builders/dockerfile.py
@@ -30,7 +30,7 @@ def write_dockerfile(
     if install_reqs_before_copy:
         content_lines.append("COPY {}/requirements.txt {}".format(path_prefix, path_prefix))
     content_lines.append("RUN if [ -e requirements.txt ];" +
-                         "then pip install --no-cache -r requirements.txt; fi")
+                         "then pip install --user --no-cache -r requirements.txt; fi")
     content_lines.append(copy_context)
 
     if docker_command:

--- a/tests/unit/builders/test_dockerfile.py
+++ b/tests/unit/builders/test_dockerfile.py
@@ -14,7 +14,7 @@ def test_writedockerfile_with_docker_cmd():
     expected = """FROM foo_bar
 WORKDIR /pre
 ENV FAIRING_RUNTIME 1
-RUN if [ -e requirements.txt ];then pip install --no-cache -r requirements.txt; fi
+RUN if [ -e requirements.txt ];then pip install --user --no-cache -r requirements.txt; fi
 COPY /pre /pre
 CMD python main.py"""
     assert actual == expected
@@ -31,7 +31,7 @@ def test_writedockerfile_without_docker_cmd():
     expected = """FROM foo_bar
 WORKDIR /pre
 ENV FAIRING_RUNTIME 1
-RUN if [ -e requirements.txt ];then pip install --no-cache -r requirements.txt; fi
+RUN if [ -e requirements.txt ];then pip install --user --no-cache -r requirements.txt; fi
 COPY /pre /pre"""
     assert actual == expected
 
@@ -49,7 +49,7 @@ def test_writedockerfile_with_early_install_reqs():
 WORKDIR /pre
 ENV FAIRING_RUNTIME 1
 COPY /pre/requirements.txt /pre
-RUN if [ -e requirements.txt ];then pip install --no-cache -r requirements.txt; fi
+RUN if [ -e requirements.txt ];then pip install --user --no-cache -r requirements.txt; fi
 COPY /pre /pre
 CMD python main.py"""
     assert actual == expected


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, running cluster builder with non root user base image(e.g. gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0) results error when user tries to install additional python package using requirements.txt file. 

Pip install without --user option installs package under /usr/local/lib path. And non root user doesn't have right to write under /usr/local/lib and this lead to Permission Denied error for pip install.

With this modification user can install additional python package regardless of container's user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE
