### PR TITLE
fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ documentation][fairing-overview].
 
 To learn the Kubeflow Fairing SDK API, read the [HTML documentation][html-doc].
 
-[fairing-overview]: https://www.kubeflow.org/docs/fairing/fairing-overview/
+[fairing-overview]: https://www.kubeflow.org/docs/components/fairing/fairing-overview/
 [html-doc]: https://kubeflow-fairing.readthedocs.io/en/latest/index.html
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The link in the README is broken, just make it correct.