### PR TITLE
Add conditional statement to dockerfile considering user of base image

### DIFF
--- a/kubeflow/fairing/builders/cluster/cluster.py
+++ b/kubeflow/fairing/builders/cluster/cluster.py
@@ -26,7 +26,8 @@ class ClusterBuilder(BaseBuilder):
                  pod_spec_mutators=None,
                  namespace=None,
                  dockerfile_path=None,
-                 cleanup=False):
+                 cleanup=False,
+                 executable_path_prefix=None):
         super().__init__(
             registry=registry,
             image_name=image_name,
@@ -41,6 +42,7 @@ class ClusterBuilder(BaseBuilder):
         self.pod_spec_mutators = pod_spec_mutators or []
         self.namespace = namespace or utils.get_default_target_namespace()
         self.cleanup = cleanup
+        self.executable_path_prefix = executable_path_prefix
 
     def build(self):
         logging.info("Building image using cluster builder.")
@@ -51,7 +53,8 @@ class ClusterBuilder(BaseBuilder):
             dockerfile_path = dockerfile.write_dockerfile(
                 path_prefix=self.preprocessor.path_prefix,
                 base_image=self.base_image,
-                install_reqs_before_copy=install_reqs_before_copy
+                install_reqs_before_copy=install_reqs_before_copy,
+                executable_path_prefix=self.executable_path_prefix
             )
         self.preprocessor.output_map[dockerfile_path] = 'Dockerfile'
         context_path, context_hash = self.preprocessor.context_tar_gz()

--- a/kubeflow/fairing/builders/docker/docker.py
+++ b/kubeflow/fairing/builders/docker/docker.py
@@ -19,7 +19,8 @@ class DockerBuilder(BaseBuilder):
                  base_image=constants.DEFAULT_BASE_IMAGE,
                  preprocessor=None,
                  push=True,
-                 dockerfile_path=None):
+                 dockerfile_path=None,
+                 executable_path_prefix=None):
         super().__init__(
             registry=registry,
             image_name=image_name,
@@ -27,6 +28,7 @@ class DockerBuilder(BaseBuilder):
             base_image=base_image,
             preprocessor=preprocessor,
             dockerfile_path=dockerfile_path)
+        self.executable_path_prefix = executable_path_prefix
 
     def build(self):
         logging.info("Building image using docker")
@@ -49,7 +51,8 @@ class DockerBuilder(BaseBuilder):
                 docker_command=docker_command,
                 path_prefix=self.preprocessor.path_prefix,
                 base_image=self.base_image,
-                install_reqs_before_copy=install_reqs_before_copy)
+                install_reqs_before_copy=install_reqs_before_copy,
+                executable_path_prefix=self.executable_path_prefix)
         self.preprocessor.output_map[dockerfile_path] = 'Dockerfile'
         context_file, context_hash = self.preprocessor.context_tar_gz()
         self.image_tag = self.full_image_name(context_hash)

--- a/kubeflow/fairing/builders/podman/podman.py
+++ b/kubeflow/fairing/builders/podman/podman.py
@@ -19,7 +19,8 @@ class PodmanBuilder(BaseBuilder):
                  preprocessor=None,
                  push=True,
                  dockerfile_path=None,
-                 tls_verify=False):
+                 tls_verify=False,
+                 executable_path_prefix=None):
         """
         Initiate a Podman builder to build and publish images
 
@@ -30,6 +31,7 @@ class PodmanBuilder(BaseBuilder):
         :param push:  whether to publish image to registry
         :param dockerfile_path:  specify the dockerfile path for image built
         :param tls_verify:  when publishing image, whether to skip tls verify
+        :param executable_path_prefix: prefix for /.local/bin. Combined path added to PATH variable
         """
         super().__init__(
             registry=registry,
@@ -39,6 +41,7 @@ class PodmanBuilder(BaseBuilder):
             preprocessor=preprocessor,
             dockerfile_path=dockerfile_path)
         self.tls_verify = tls_verify
+        self.executable_path_prefix = executable_path_prefix
 
     def build(self):
         logging.info("Building image using podman")
@@ -98,7 +101,8 @@ class PodmanBuilder(BaseBuilder):
                     docker_command=docker_command,
                     path_prefix=self.preprocessor.path_prefix,
                     base_image=self.base_image,
-                    install_reqs_before_copy=install_reqs_before_copy)
+                    install_reqs_before_copy=install_reqs_before_copy,
+                    executable_path_prefix=self.executable_path_prefix)
             self.preprocessor.output_map[dockerfile_path] = 'Dockerfile'
             self.context_file, context_hash = self.preprocessor.context_tar_gz()
             self.image_tag = self.full_image_name(context_hash)

--- a/tests/unit/builders/test_dockerfile.py
+++ b/tests/unit/builders/test_dockerfile.py
@@ -14,7 +14,9 @@ def test_writedockerfile_with_docker_cmd():
     expected = """FROM foo_bar
 WORKDIR /pre
 ENV FAIRING_RUNTIME 1
-RUN if [ -e requirements.txt ];then pip install --no-cache -r requirements.txt; fi
+RUN if [ -e requirements.txt ];then if [ "$(whoami)" = "root" ];\
+then pip install --no-cache -r requirements.txt;\
+else pip install --user --no-cache -r requirements.txt; fi; fi
 COPY /pre /pre
 CMD python main.py"""
     assert actual == expected
@@ -31,7 +33,9 @@ def test_writedockerfile_without_docker_cmd():
     expected = """FROM foo_bar
 WORKDIR /pre
 ENV FAIRING_RUNTIME 1
-RUN if [ -e requirements.txt ];then pip install --no-cache -r requirements.txt; fi
+RUN if [ -e requirements.txt ];then if [ "$(whoami)" = "root" ];\
+then pip install --no-cache -r requirements.txt;\
+else pip install --user --no-cache -r requirements.txt; fi; fi
 COPY /pre /pre"""
     assert actual == expected
 
@@ -49,7 +53,30 @@ def test_writedockerfile_with_early_install_reqs():
 WORKDIR /pre
 ENV FAIRING_RUNTIME 1
 COPY /pre/requirements.txt /pre
-RUN if [ -e requirements.txt ];then pip install --no-cache -r requirements.txt; fi
+RUN if [ -e requirements.txt ];then if [ "$(whoami)" = "root" ];\
+then pip install --no-cache -r requirements.txt;\
+else pip install --user --no-cache -r requirements.txt; fi; fi
+COPY /pre /pre
+CMD python main.py"""
+    assert actual == expected
+
+
+def test_writedockerfile_with_executable_path_prefix():
+    _, tmp_file = tempfile.mkstemp()
+    dockerfile.write_dockerfile(
+        destination=tmp_file,
+        docker_command=["python", "main.py"],
+        path_prefix="/pre",
+        base_image="foo_bar",
+        executable_path_prefix="/home/jovyan")
+    actual = open(tmp_file, 'r').read()
+    expected = """FROM foo_bar
+WORKDIR /pre
+ENV FAIRING_RUNTIME 1
+ENV PATH /home/jovyan/.local/bin:$PATH
+RUN if [ -e requirements.txt ];then if [ "$(whoami)" = "root" ];\
+then pip install --no-cache -r requirements.txt;\
+else pip install --user --no-cache -r requirements.txt; fi; fi
 COPY /pre /pre
 CMD python main.py"""
     assert actual == expected


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
As I wrote before(https://github.com/kubeflow/fairing/pull/530), if user of base image is non-root then pip install command should have --user option to avoid permission problem. Also, $HOME/.local/lib path should be included to PATH variable for package executable.

However, there's no easy way to get value of home path unless it is explicitly set by ENV directive. 
So, I added executable_path_prefix option to specify home path of non-root user.

If executable_path_prefix is given, ENV directive will be added to include $HOME/.local/lib.
Fairing user doesn't need to specify executable_path_prefix if $HOME/.local/lib path is already included in a base image.

Base image with root user will be processed same as before.

There can be a better way of considering user of base image.
Any ideas are welcome.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #None

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
