### PR TITLE
Fix for failing Training Job on py 3.8+

### DIFF
--- a/kubeflow/fairing/preprocessors/function.py
+++ b/kubeflow/fairing/preprocessors/function.py
@@ -64,10 +64,11 @@ class FunctionPreProcessor(BasePreProcessor):
 
         # Make sure cloudpickle can be imported as a module
         cloudpickle_dir = os.path.dirname(cloudpickle.__file__)
-        self.output_map[os.path.join(cloudpickle_dir, '__init__.py')] = \
-            os.path.join(path_prefix, "cloudpickle", '__init__.py')
-        self.output_map[os.path.join(cloudpickle_dir, 'cloudpickle.py')] = \
-            os.path.join(path_prefix, "cloudpickle", 'cloudpickle.py')
+        cloudpickle_files = ['__init__.py', 'cloudpickle.py', 'cloudpickle_fast.py']
+        cpf_dest = os.path.join(path_prefix, "cloudpickle")
+        cpf_output_map = {os.path.join(cloudpickle_dir, cpf): os.path.join(cpf_dest, cpf) for cpf in cloudpickle_files
+                          if os.path.exists(os.path.join(cloudpickle_dir, cpf))}
+        self.output_map.update(cpf_output_map)
 
         _, temp_payload_file = tempfile.mkstemp()
         with open(temp_payload_file, "wb") as f:

--- a/kubeflow/fairing/preprocessors/function.py
+++ b/kubeflow/fairing/preprocessors/function.py
@@ -66,7 +66,8 @@ class FunctionPreProcessor(BasePreProcessor):
         cloudpickle_dir = os.path.dirname(cloudpickle.__file__)
         cloudpickle_files = ['__init__.py', 'cloudpickle.py', 'cloudpickle_fast.py']
         cpf_dest = os.path.join(path_prefix, "cloudpickle")
-        cpf_output_map = {os.path.join(cloudpickle_dir, cpf): os.path.join(cpf_dest, cpf) for cpf in cloudpickle_files
+        cpf_output_map = {os.path.join(cloudpickle_dir, cpf): os.path.join(cpf_dest, cpf)
+                          for cpf in cloudpickle_files
                           if os.path.exists(os.path.join(cloudpickle_dir, cpf))}
         self.output_map.update(cpf_output_map)
 


### PR DESCRIPTION
I've encountered the issue similar to described in https://github.com/kubeflow/fairing/issues/452.
It occurs when user uses function preprocessor + cloudpicke version containing cloudpickle_fast.py + python 3.8+.
 
The root cause is that newer versions of cloudpickle contain cloudpickle_fast.py and that file isn't copied by preprocessor during image preparation.

So, this PR aims to append mentioned above file along with the rest of cloudpickle package.

By the way, what's the reason for copying that package into image ? Wouldn't it be better to copy egg there f.e. and install it on start up ?