### PR TITLE
Update gcpserving.py

### DIFF
--- a/kubeflow/fairing/deployers/gcp/gcpserving.py
+++ b/kubeflow/fairing/deployers/gcp/gcpserving.py
@@ -26,7 +26,7 @@ class GCPServingDeployer(DeployerInterface):
         if 'python_version' not in self._deploy_kwargs:
             self._deploy_kwargs['python_version'] = '3.5'
 
-    def deploy(self, pod_template_spec):
+    def deploy(self, pod_template_spec = ""):
         """Deploys the model to Cloud ML Engine.
 
         :param pod_template_spec: pod spec template of training job


### PR DESCRIPTION
pod_template_spec is a required field in deploy() but it looks like the parameter is never used. Maybe default to making it an empty string so users are not confused at what should be passed in to run the deployment.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
