### PR TITLE
Fix problem that unable to get notebook filename on JupyterLab 3.0

### DIFF
--- a/kubeflow/fairing/notebook/notebook_util.py
+++ b/kubeflow/fairing/notebook/notebook_util.py
@@ -5,13 +5,19 @@ import re
 from notebook.notebookapp import list_running_servers
 import requests
 from requests.compat import urljoin
+import importlib
 
 
 def get_notebook_name(): #pylint:disable=inconsistent-return-statements
     """Return the full path of the jupyter notebook. """
     kernel_id = re.search('kernel-(.*).json',
                           ipykernel.connect.get_connection_file()).group(1)
-    servers = list_running_servers()
+    jupyter_server_spec = importlib.util.find_spec("jupyter_server")
+    if jupyter_server_spec is not None:
+        from jupyter_server import serverapp
+        servers = serverapp.list_running_servers()
+    else:
+        servers = list_running_servers()
     for ss in servers:
         response = requests.get(urljoin(ss['url'], 'api/sessions'),
                                 params={'token': ss.get('token', '')})


### PR DESCRIPTION
**What this PR does / why we need it**:
The `notebookapp` has been changed from JupyterLab 3.0 to `serverapp`, so the list of servers is not returned.
So if there is a `Jupiter_server` module, I changed it to get the list of servers from `serverapp`.


**Which issue(s) this PR fixes**
Fixes #551 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed to return notebook filename on JupyterLab 3.0 
```
