### PR TITLE
allow caching and overriding single_snapshot for kaniko

### DIFF
--- a/kubeflow/fairing/builders/cluster/cluster.py
+++ b/kubeflow/fairing/builders/cluster/cluster.py
@@ -27,7 +27,9 @@ class ClusterBuilder(BaseBuilder):
                  namespace=None,
                  dockerfile_path=None,
                  cleanup=False,
-                 executable_path_prefix=None):
+                 executable_path_prefix=None,
+                 cache=False,
+                 single_snapshot=True):
         super().__init__(
             registry=registry,
             image_name=image_name,
@@ -43,6 +45,8 @@ class ClusterBuilder(BaseBuilder):
         self.namespace = namespace or utils.get_default_target_namespace()
         self.cleanup = cleanup
         self.executable_path_prefix = executable_path_prefix
+        self.cache = cache
+        self.single_snapshot = single_snapshot
 
     def build(self):
         logging.info("Building image using cluster builder.")
@@ -68,7 +72,7 @@ class ClusterBuilder(BaseBuilder):
         labels = {'fairing-builder': 'kaniko'}
         labels['fairing-build-id'] = str(uuid.uuid1())
         pod_spec = self.context_source.generate_pod_spec(
-            self.image_tag, self.push)
+            self.image_tag, self.push, self.cache, self.single_snapshot)
         for fn in self.pod_spec_mutators:
             fn(self.manager, pod_spec, self.namespace)
 

--- a/kubeflow/fairing/builders/cluster/minio_context.py
+++ b/kubeflow/fairing/builders/cluster/minio_context.py
@@ -32,7 +32,7 @@ class MinioContextSource(ContextSourceInterface):
                                                bucket_name=bucket_name,
                                                file_to_upload=context_filename)
 
-    def generate_pod_spec(self, image_name, push):  # pylint: disable=arguments-differ
+    def generate_pod_spec(self, image_name, push, cache=False, single_snapshot=True):  # pylint: disable=arguments-differ
         """
         :param image_name: name of image to be built
         :param push: whether to push image to given registry or not
@@ -40,11 +40,16 @@ class MinioContextSource(ContextSourceInterface):
         args = [
             "--dockerfile=Dockerfile",
             "--destination=" + image_name,
-            "--context=" + self.uploaded_context_url,
-            "--single-snapshot"
+            "--context=" + self.uploaded_context_url
         ]
+        if single_snapshot:
+            args.append("--single-snapshot")
+
         if not push:
             args.append("--no-push")
+
+        if cache:
+            args.append("--cache=true")
 
         return client.V1PodSpec(
             containers=[


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In our environment, image builds take a long time because the base layer is large and our updates are small. We have to use the in-cluster builder and this allows us to snapshot and cache the intermediate layers so subsequent builds become faster. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

This PR should be backwards compatible with older versions.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enables creation of a cluster builder with the ability to cache and not use single_snapshots to enable faster incremental builds in certain situations:
```
            cluster_builder = ClusterBuilder(registry=constants.DEFAULT_DOCKER_REGISTRY,
                                             base_image=self._base_image_name,
                                             preprocessor=preprocessor,
                                             image_name=image_name,
                                             dockerfile_path='Dockerfile',
                                             context_source=create_minio_context_source(),
                                             cache=True,
                                             single_snapshot=False)
```

```
