### PR TITLE
Add node selector for pod_spec_mutator

### DIFF
--- a/kubeflow/fairing/kubernetes/utils.py
+++ b/kubeflow/fairing/kubernetes/utils.py
@@ -113,3 +113,20 @@ def add_env(env_vars):
             else:
                 pod_spec.containers[0].env = env_list
     return _add_env
+
+
+def get_node_selector(node_selector):
+    """This function for pod_spec_mutators to designate node selector.
+
+    :param node_selector: dict of selection constraint
+    :return: obejct: The mutator fucntion for setting node selector
+
+    """
+
+    def _node_selector(kube_master, pod_spec, namespace): #pylint:disable=unused-argument
+        if node_selector is None:
+            return
+        if pod_spec.containers and len(pod_spec.containers) >= 1:
+            pod_spec.node_selector = node_selector
+
+    return _node_selector


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add a k8s util function to designate node selector for pod_spec_mutator.

When I use a Kubeflow fairing for training, it is hard to start designate node selector which can choose a zone it would be deployed. It would be helpful when users want to mutator pod spec easily.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #559 

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
