### PR TITLE
add config size information in the append builder to support image pull in a podman environment

### DIFF
--- a/containerregistry/client/v2_2/append_.py
+++ b/containerregistry/client/v2_2/append_.py
@@ -82,6 +82,7 @@ class Layer(docker_image.DockerImage):
     self._config_file = json.dumps(config_file, sort_keys=True)
     manifest['config']['digest'] = docker_digest.SHA256(
         self._config_file.encode('utf8'))
+    manifest['config']['size'] = len(self._config_file)
     self._manifest = json.dumps(manifest, sort_keys=True)
 
   def manifest(self):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When trying to pull an image built by append builder using podman, blob size mismatch error occurs.
This is due to config size mismatch in manifest.

current append builder only appends a new layer and updates config digest in the manifest.
so the config size of the newly built image manifest remains the same of that of the base image used to build a new image.
This doesn't seem to be a problem when trying to pull an image using docker but when trying to pull an image using podman, size mismatch error occurs.

This PR added a code to add config size information in the manifest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #568 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
